### PR TITLE
feat: add resilient tx confirmation with RPC polling fallback

### DIFF
--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -2,7 +2,13 @@ import { ProviderType } from '@hyperlane-xyz/sdk';
 import { BigNumber } from 'ethers';
 import { type Chain } from 'viem';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { preEstimateGasForEvmTxs, raceViemProviderBuilder, withWcRpcFirst } from '../rpcUtils';
+import {
+  fibonacciDelays,
+  preEstimateGasForEvmTxs,
+  raceViemProviderBuilder,
+  resilientConfirm,
+  withWcRpcFirst,
+} from '../rpcUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -154,7 +160,10 @@ vi.mock('@wagmi/core', () => ({
 }));
 
 vi.mock('../../../utils/logger', () => ({
-  logger: { warn: (...args: any[]) => mockLoggerWarn(...args) },
+  logger: {
+    warn: (...args: any[]) => mockLoggerWarn(...args),
+    debug: vi.fn(),
+  },
 }));
 
 describe('preEstimateGasForEvmTxs', () => {
@@ -232,5 +241,127 @@ describe('preEstimateGasForEvmTxs', () => {
 
     expect(txs[0].transaction.gasLimit).toEqual(BigNumber.from('120000'));
     expect(txs[1].transaction).not.toHaveProperty('gasLimit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fibonacciDelays
+// ---------------------------------------------------------------------------
+
+describe('fibonacciDelays', () => {
+  test('yields Fibonacci sequence in milliseconds', () => {
+    const gen = fibonacciDelays();
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000]);
+  });
+
+  test('caps delays at maxDelayMs', () => {
+    const gen = fibonacciDelays(5000);
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 5000, 5000, 5000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resilientConfirm
+// ---------------------------------------------------------------------------
+
+describe('resilientConfirm', () => {
+  const mockConfig = {} as any;
+  const mockGetTransactionReceipt = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetPublicClient.mockReturnValue({
+      getTransactionReceipt: mockGetTransactionReceipt,
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('resolves with wallet confirm when it wins the race', async () => {
+    const walletReceipt = { type: 'ethersV5', receipt: { hash: '0xabc' } };
+    const walletConfirm = vi.fn().mockResolvedValue(walletReceipt);
+    // RPC never finds receipt
+    mockGetTransactionReceipt.mockRejectedValue(new Error('not found'));
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Wallet resolves immediately, before the 5s initial delay even fires
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe(walletReceipt);
+  });
+
+  test('resolves with RPC poll when wallet confirm hangs', async () => {
+    const rpcReceipt = { status: 'success', transactionHash: '0xhash' };
+    // Wallet never resolves
+    const walletConfirm = () => new Promise<never>(() => {});
+    // RPC succeeds on first poll (after 5s initial delay)
+    mockGetTransactionReceipt.mockResolvedValue(rpcReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Fire the 5s initial delay timer synchronously, then let microtasks settle
+    vi.advanceTimersByTime(5100);
+    const result = await promise;
+
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: rpcReceipt });
+  });
+
+  test('rejects when transaction is reverted on-chain', async () => {
+    const revertedReceipt = { status: 'reverted', transactionHash: '0xhash' };
+    const walletConfirm = () => new Promise<never>(() => {});
+    mockGetTransactionReceipt.mockResolvedValue(revertedReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Fire the 5s initial delay timer synchronously, then let microtasks settle
+    vi.advanceTimersByTime(5100);
+
+    await expect(promise).rejects.toThrow('Transaction reverted on-chain');
+  });
+
+  test('rejects with wallet error when both fail', async () => {
+    const walletError = new Error('Wallet rejected');
+    const walletConfirm = vi.fn().mockImplementation(() => Promise.reject(walletError));
+    mockGetPublicClient.mockReturnValue(null);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+
+    await expect(promise).rejects.toThrow('Wallet rejected');
+  });
+
+  test('RPC polling uses Fibonacci backoff after 5s initial delay', async () => {
+    const rpcReceipt = { status: 'success', transactionHash: '0xhash' };
+    const walletConfirm = () => new Promise<never>(() => {});
+    // Fail 3 times, then succeed on 4th call
+    mockGetTransactionReceipt
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValue(rpcReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+
+    // 5s initial delay, then first poll fires (fails)
+    await vi.advanceTimersByTimeAsync(5100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(1);
+
+    // Fibonacci delay 1: 1s — second poll (fails)
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(2);
+
+    // Fibonacci delay 2: 1s — third poll (fails)
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(3);
+
+    // Fibonacci delay 3: 2s — fourth poll (succeeds)
+    await vi.advanceTimersByTimeAsync(2100);
+    const result = await promise;
+
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(4);
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: rpcReceipt });
   });
 });

--- a/src/features/chains/rpcUtils.ts
+++ b/src/features/chains/rpcUtils.ts
@@ -11,7 +11,12 @@
  * connector always has a working endpoint.
  */
 
-import { ChainMetadata, ProviderType, ViemProvider } from '@hyperlane-xyz/sdk';
+import {
+  ChainMetadata,
+  ProviderType,
+  TypedTransactionReceipt,
+  ViemProvider,
+} from '@hyperlane-xyz/sdk';
 import { getPublicClient } from '@wagmi/core';
 import { BigNumber } from 'ethers';
 import { type Chain, createPublicClient, custom } from 'viem';
@@ -149,5 +154,165 @@ export async function preEstimateGasForEvmTxs(
     } catch (e) {
       logger.warn('Gas pre-estimation failed, wallet will estimate during signing', e);
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resilient transaction confirmation
+// ---------------------------------------------------------------------------
+
+const INITIAL_POLL_DELAY_MS = 5_000; // wait before first poll
+const MAX_POLL_DURATION_MS = 60 * 60 * 1_000; // 1 hour
+const MAX_FIBONACCI_DELAY_MS = 30_000; // cap individual interval at 30s
+const TX_REVERTED_ERROR = 'Transaction reverted on-chain';
+
+/**
+ * Fibonacci delay generator for polling intervals (in milliseconds).
+ * Yields: 1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000, 30000, 30000, …
+ */
+export function* fibonacciDelays(maxDelayMs = MAX_FIBONACCI_DELAY_MS): Generator<number> {
+  let a = 1_000;
+  let b = 1_000;
+  while (true) {
+    yield Math.min(a, maxDelayMs);
+    [a, b] = [b, a + b];
+  }
+}
+
+/**
+ * Poll the blockchain directly for a transaction receipt using Fibonacci backoff.
+ * Uses the wagmi public client which already races across all configured RPCs
+ * via {@link raceTransport}.
+ */
+async function pollForReceipt(
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  signal: AbortSignal,
+): Promise<TypedTransactionReceipt> {
+  const publicClient = getPublicClient(wagmiConfig, { chainId });
+  if (!publicClient) throw new Error('No public client available for RPC polling');
+
+  const startTime = Date.now();
+  const delays = fibonacciDelays();
+
+  // Wait before first poll to give the wallet a chance to confirm on its own
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, INITIAL_POLL_DELAY_MS);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('Polling cancelled'));
+      },
+      { once: true },
+    );
+  });
+
+  while (!signal.aborted) {
+    if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
+      throw new Error('RPC polling timed out');
+    }
+
+    try {
+      const receipt = await publicClient.getTransactionReceipt({
+        hash: txHash as `0x${string}`,
+      });
+
+      if (receipt.status === 'reverted') {
+        throw new Error(TX_REVERTED_ERROR);
+      }
+
+      logger.debug('RPC polling confirmed tx:', txHash);
+      return { type: ProviderType.Viem, receipt } as TypedTransactionReceipt;
+    } catch (error: any) {
+      // Propagate revert — the tx genuinely failed
+      if (error?.message === TX_REVERTED_ERROR) throw error;
+      // Otherwise tx isn't mined yet or RPC hiccup — wait and retry
+    }
+
+    const delay = delays.next().value!;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, delay);
+      signal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('Polling cancelled'));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  throw new Error('Polling cancelled');
+}
+
+/**
+ * Race the wallet's confirm() against direct RPC polling.
+ *
+ * WalletConnect behaviour varies across wallet brands — some wallets fail to
+ * resolve the confirmation callback even after the tx lands on-chain. This
+ * function polls the blockchain directly (with Fibonacci backoff across all
+ * configured RPCs) in parallel with the wallet's own confirm(). Whichever
+ * returns first wins.
+ *
+ * Semantics (differs from Promise.any):
+ * - Either fulfills → resolve immediately, abort the other.
+ * - RPC rejects with "reverted" → reject immediately (definitive on-chain failure).
+ * - Wallet rejects but RPC still running → keep polling (wallet errors are not definitive).
+ * - Both reject → surface the wallet error (more informative for the user).
+ */
+export async function resilientConfirm(
+  walletConfirm: () => Promise<TypedTransactionReceipt>,
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+): Promise<TypedTransactionReceipt> {
+  const controller = new AbortController();
+  const cleanup = () => controller.abort();
+
+  let walletDone = false;
+  let rpcDone = false;
+  let walletError: Error | undefined;
+
+  // Signals when both legs have failed so Promise.race can reject
+  let signalBothFailed!: () => void;
+  const bothFailedBarrier = new Promise<void>((r) => {
+    signalBothFailed = r;
+  });
+
+  // Wallet leg: on success → resolve; on failure → swallow (keep RPC alive)
+  const walletLeg = walletConfirm().catch((err) => {
+    walletDone = true;
+    walletError = err;
+    if (rpcDone) signalBothFailed();
+    return new Promise<TypedTransactionReceipt>(() => {}); // hang until RPC settles
+  });
+
+  // RPC leg: on success → resolve; on revert → throw; on other failure → swallow
+  const rpcLeg = pollForReceipt(txHash, wagmiConfig, chainId, controller.signal).catch((err) => {
+    if (err?.message === TX_REVERTED_ERROR) throw err; // definitive on-chain failure
+    rpcDone = true;
+    if (walletDone) signalBothFailed();
+    return new Promise<TypedTransactionReceipt>(() => {}); // hang until wallet settles
+  });
+
+  // Both-failed leg: rejects with wallet error when both legs have failed
+  const bothFailedLeg = bothFailedBarrier.then((): never => {
+    throw walletError ?? new Error('Both wallet and RPC polling failed');
+  });
+
+  // Prevent unhandled rejection if one leg wins and the other later rejects
+  rpcLeg.catch(() => {});
+  bothFailedLeg.catch(() => {});
+
+  try {
+    const result = await Promise.race([walletLeg, rpcLeg, bothFailedLeg]);
+    cleanup();
+    return result;
+  } catch (err) {
+    cleanup();
+    throw err;
   }
 }

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -133,6 +133,12 @@ vi.mock('../../chains/utils', () => ({
   getChainDisplayName: getChainDisplayNameMock,
 }));
 
+vi.mock('../../chains/rpcUtils', () => ({
+  preEstimateGasForEvmTxs: vi.fn(),
+  // Pass through to wallet confirm — resilientConfirm is tested in rpcUtils.test.ts
+  resilientConfirm: vi.fn((walletConfirm: () => Promise<any>) => walletConfirm()),
+}));
+
 vi.mock('../../tokens/hooks', () => ({
   useWarpCore: () => warpCoreMock,
   getTokenByIndex: getTokenByIndexMock,

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
-import { preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { preEstimateGasForEvmTxs, resilientConfirm } from '../chains/rpcUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -252,8 +252,9 @@ async function executeTransfer({
 
     // Pre-estimate gas via the CORS-resilient public client so wagmi doesn't
     // attempt estimation through the WalletConnect connector's rpcMap.
-    if (originProtocol === ProtocolType.Ethereum) {
-      const chainId = multiProvider.getChainMetadata(origin).chainId as number;
+    const isEvm = originProtocol === ProtocolType.Ethereum;
+    const chainId = isEvm ? (multiProvider.getChainMetadata(origin).chainId as number) : 0;
+    if (isEvm) {
       await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, txs as any);
     }
 
@@ -296,7 +297,12 @@ async function executeTransfer({
           transferIndex,
           (transferStatus = txCategoryToStatuses[tx.category][1]),
         );
-        txReceipt = await confirm();
+        // Race wallet confirmation against direct RPC polling for EVM chains.
+        // WalletConnect behaviour varies across wallets — some fail to resolve
+        // the confirm callback even after the tx lands on-chain.
+        txReceipt = isEvm
+          ? await resilientConfirm(confirm, hash, wagmiConfig, chainId)
+          : await confirm();
         const description = toTitleCase(tx.category);
         logger.debug(`${description} transaction confirmed, hash:`, hash);
         toastTxSuccess(`${description} transaction sent!`, hash, origin);


### PR DESCRIPTION
Issue Before Fix                                                                                                                                                                 
                                                            
  WalletConnect's confirm() callback is unreliable. After a user signs a transaction, the app calls confirm() to wait for the transaction receipt. This promise depends entirely on
   the wallet relaying the confirmation back through WalletConnect's relay protocol.                                                                                               
                                                                                                                                                                                   
  Problem: Different wallet brands (MetaMask, Trust Wallet, Rainbow, etc.) implement WalletConnect differently. Some wallets fail to resolve the confirm() callback even after the 
  transaction has already landed on-chain. When this happens, the UI gets stuck on "Confirming Transfer..." forever — the transaction succeeded on-chain, but the app never knows.
                                                                                                                                                                                   
  There was no fallback mechanism. If the wallet didn't respond, the user had to manually refresh and check their transfer history.                                                
   
  ---                                                                                                                                                                              
  What's Fixed                                              
              
  Added resilientConfirm() — a function that races the wallet's confirm() against direct blockchain polling via the app's configured RPCs.
                                                                                                                                                                                   
  Key behaviors:
  - 5-second initial delay before starting RPC polling (gives wallet a chance to confirm on its own)                                                                               
  - Fibonacci backoff polling intervals: 1s, 1s, 2s, 3s, 5s, 8s, 13s, 21s, 30s (capped)                                                                                            
  - 1-hour max poll duration                                                           
  - Polls via getPublicClient which already uses the existing raceTransport (fires all configured RPCs in parallel)                                                                
  - Only applies to EVM chains — non-EVM chains still use confirm() directly                                       
                                                                                                                                                                                   
  Race semantics:                                                                                                                                                                  
                                                                                                                                                                                   
  ┌───────────────────────────────────┬────────────────────────────────────────────────┐                                                                                           
  │             Scenario              │                     Result                     │
  ├───────────────────────────────────┼────────────────────────────────────────────────┤                                                                                           
  │ Wallet resolves first             │ Use wallet receipt, stop polling               │
  ├───────────────────────────────────┼────────────────────────────────────────────────┤
  │ RPC finds receipt first           │ Use RPC receipt, stop waiting for wallet       │                                                                                           
  ├───────────────────────────────────┼────────────────────────────────────────────────┤                                                                                           
  │ RPC detects revert                │ Reject immediately (definitive failure)        │                                                                                           
  ├───────────────────────────────────┼────────────────────────────────────────────────┤                                                                                           
  │ Wallet rejects, RPC still running │ Keep polling (wallet errors aren't definitive) │
  ├───────────────────────────────────┼────────────────────────────────────────────────┤                                                                                           
  │ Both fail                         │ Surface wallet error to user                   │
  └───────────────────────────────────┴────────────────────────────────────────────────┘                                                                                           
   
  ---                                                                                                                                                                              
  Flow After Fix                                            
                
  User signs tx → wallet returns hash
           │                                                                                                                                                                       
           ├─── Wallet leg: walletConfirm()                                                                                                                                        
           │         (waiting for wallet callback)                                                                                                                                 
           │                                                                                                                                                                       
           └─── RPC leg: wait 5s, then poll blockchain      
                          ↓                                                                                                                                                        
                     getTransactionReceipt()                                                                                                                                       
                          ↓ (not found)
                     wait 1s → poll again                                                                                                                                          
                          ↓ (not found)                                                                                                                                            
                     wait 1s → poll again
                          ↓ (not found)                                                                                                                                            
                     wait 2s → poll again                   
                          ↓ (found!)                                                                                                                                               
                     ✅ return receipt                                                                                                                                              
           │                                                                                                                                                                       
      First to succeed wins → continue transfer flow                                                                                                                               
                                                                                                                                                                                   
  ---                                                       
  Sample Cases                                                                                                                                                                     
                                                                                                                                                                                   
  Case 1: Wallet responds normally (most wallets)
                                                                                                                                                                                   
  1. User signs transfer on MetaMask via WalletConnect                                                                                                                             
  2. resilientConfirm starts both legs                                                                                                                                             
  3. Wallet confirms after ~3 seconds                                                                                                                                              
  4. Wallet wins the race (RPC hasn't even started polling yet — still in 5s delay)                                                                                                
  5. RPC polling is aborted, flow continues normally                                                                                                                               
                                                                                                                                                                                   
  Case 2: Wallet hangs (e.g. some Trust Wallet versions)                                                                                                                           
                                                                                                                                                                                   
  1. User signs transfer on Trust Wallet via WalletConnect                                                                                                                         
  2. resilientConfirm starts both legs                      
  3. Wallet's confirm() never resolves (Trust Wallet doesn't relay the receipt)                                                                                                    
  4. After 5s, RPC polling starts → calls getTransactionReceipt on all configured RPCs                                                                                             
  5. First poll: not mined yet → wait 1s                                                                                                                                           
  6. Second poll: receipt found with status: 'success'                                                                                                                             
  7. RPC wins the race, wallet leg is abandoned, flow continues                                                                                                                    
                                                                                                                                                                                   
  Case 3: Transaction reverts on-chain                                                                                                                                             
                                                                                                                                                                                   
  1. User signs transfer, wallet doesn't respond                                                                                                                                   
  2. After 5s, RPC polling starts                           
  3. First poll finds receipt with status: 'reverted'                                                                                                                              
  4. resilientConfirm rejects immediately with "Transaction reverted on-chain"
  5. Error toast shown to user — no need to wait for wallet                                                                                                                        
                                                                                                                                                                                   
  Case 4: Wallet rejects but tx might still be pending                                                                                                                             
                                                                                                                                                                                   
  1. User signs transfer                                                                                                                                                           
  2. WalletConnect relay errors out → wallet confirm() rejects with a network error
  3. RPC polling is still running — keeps checking the blockchain                                                                                                                  
  4. Eventually finds the receipt on-chain                                                                                                                                         
  5. Transfer succeeds despite the wallet error 