### PR TITLE
Fix/metamask mobile walletconnect chain switch

### DIFF
--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -2,7 +2,13 @@ import { ProviderType } from '@hyperlane-xyz/sdk';
 import { BigNumber } from 'ethers';
 import { type Chain } from 'viem';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { preEstimateGasForEvmTxs, raceViemProviderBuilder, withWcRpcFirst } from '../rpcUtils';
+import {
+  ensureWalletOnChain,
+  preEstimateGasForEvmTxs,
+  raceViemProviderBuilder,
+  waitForChainSwitch,
+  withWcRpcFirst,
+} from '../rpcUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -147,10 +153,14 @@ describe('withWcRpcFirst', () => {
 
 const mockEstimateGas = vi.fn();
 const mockGetPublicClient = vi.fn();
+const mockGetAccount = vi.fn();
+const mockSwitchChain = vi.fn();
 const mockLoggerWarn = vi.fn();
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: (...args: any[]) => mockGetPublicClient(...args),
+  getAccount: (...args: any[]) => mockGetAccount(...args),
+  switchChain: (...args: any[]) => mockSwitchChain(...args),
 }));
 
 vi.mock('../../../utils/logger', () => ({
@@ -232,5 +242,141 @@ describe('preEstimateGasForEvmTxs', () => {
 
     expect(txs[0].transaction.gasLimit).toEqual(BigNumber.from('120000'));
     expect(txs[1].transaction).not.toHaveProperty('gasLimit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForChainSwitch
+// ---------------------------------------------------------------------------
+
+describe('waitForChainSwitch', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('resolves immediately when wallet is already on the correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(waitForChainSwitch(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls until wallet reports the correct chain', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // first poll: wrong chain
+      .mockReturnValue({ chainId: 1 }); // second poll: correct chain
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500); // fire one poll interval
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(2);
+  });
+
+  test('resolves after multiple polls', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(1_000); // two poll intervals
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws ChainMismatchError after timeout', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 1, 1_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('timeout error includes chain id and duration', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 42, 2_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(p).rejects.toThrow(/chain 42/);
+    await expect(p).rejects.toThrow(/2s/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureWalletOnChain
+// ---------------------------------------------------------------------------
+
+describe('ensureWalletOnChain', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('returns immediately without calling switchChain when already on correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).not.toHaveBeenCalled();
+  });
+
+  test('calls switchChain with the correct arguments when chain does not match', async () => {
+    // First getAccount call (initial check) returns wrong chain;
+    // second call (inside waitForChainSwitch) returns correct chain.
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).toHaveBeenCalledWith(mockConfig, { chainId: 1 });
+  });
+
+  test('swallows switchChain rejection and continues polling', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // initial check
+      .mockReturnValueOnce({ chainId: 999 }) // waitForChainSwitch first poll
+      .mockReturnValue({ chainId: 1 }); // waitForChainSwitch second poll
+    mockSwitchChain.mockRejectedValue(new Error('User rejected'));
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('throws ChainMismatchError when chain never switches (timeout)', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    // Advance past the full 30 s default timeout
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('does not call switchChain a second time after initial call fails', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockRejectedValue(new Error('rejected'));
+
+    await ensureWalletOnChain(mockConfig, 1);
+    // switchChain should have been called exactly once (not retried internally)
+    expect(mockSwitchChain).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -337,9 +337,7 @@ describe('ensureWalletOnChain', () => {
   test('calls switchChain with the correct arguments when chain does not match', async () => {
     // First getAccount call (initial check) returns wrong chain;
     // second call (inside waitForChainSwitch) returns correct chain.
-    mockGetAccount
-      .mockReturnValueOnce({ chainId: 999 })
-      .mockReturnValue({ chainId: 1 });
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
     mockSwitchChain.mockResolvedValue(undefined);
 
     await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
@@ -370,9 +368,7 @@ describe('ensureWalletOnChain', () => {
   });
 
   test('does not call switchChain a second time after initial call fails', async () => {
-    mockGetAccount
-      .mockReturnValueOnce({ chainId: 999 })
-      .mockReturnValue({ chainId: 1 });
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
     mockSwitchChain.mockRejectedValue(new Error('rejected'));
 
     await ensureWalletOnChain(mockConfig, 1);

--- a/src/features/chains/rpcUtils.ts
+++ b/src/features/chains/rpcUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { ChainMetadata, ProviderType, ViemProvider } from '@hyperlane-xyz/sdk';
-import { getPublicClient } from '@wagmi/core';
+import { getAccount, getPublicClient, switchChain } from '@wagmi/core';
 import { BigNumber } from 'ethers';
 import { type Chain, createPublicClient, custom } from 'viem';
 import { type Config as WagmiConfig } from 'wagmi';
@@ -150,4 +150,51 @@ export async function preEstimateGasForEvmTxs(
       logger.warn('Gas pre-estimation failed, wallet will estimate during signing', e);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// WalletConnect chain-switch resilience
+// ---------------------------------------------------------------------------
+
+const CHAIN_SWITCH_POLL_MS = 500;
+const CHAIN_SWITCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Poll wagmi's getAccount until the active chain matches `chainId`.
+ *
+ * WalletConnect with MetaMask mobile can take several seconds after switchChain
+ * resolves before the wagmi store reflects the new chain. Polling here avoids
+ * the hard-coded 2 s sleep in @hyperlane-xyz/widgets which is often too short.
+ */
+export async function waitForChainSwitch(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  timeoutMs = CHAIN_SWITCH_TIMEOUT_MS,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (getAccount(wagmiConfig).chainId === chainId) return;
+    await new Promise<void>((r) => setTimeout(r, CHAIN_SWITCH_POLL_MS));
+  }
+  throw new Error(
+    `ChainMismatchError: wallet did not switch to chain ${chainId} within ${timeoutMs / 1000}s`,
+  );
+}
+
+/**
+ * Switch the wallet to `chainId` (if not already there) and wait for wagmi to
+ * reflect the change before returning. Safe to call before every EVM transaction.
+ */
+export async function ensureWalletOnChain(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+): Promise<void> {
+  if (getAccount(wagmiConfig).chainId === chainId) return;
+  try {
+    await switchChain(wagmiConfig, { chainId });
+  } catch {
+    // Ignore — wallet may reject if already on the right chain or user cancels.
+    // waitForChainSwitch below will throw with a clear message if it still fails.
+  }
+  await waitForChainSwitch(wagmiConfig, chainId);
 }

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -13,6 +13,8 @@ const {
   tryGetMsgIdMock,
   sendTransactionMock,
   sendMultiTransactionMock,
+  mockEnsureWalletOnChain,
+  mockPreEstimateGasForEvmTxs,
   populateApproveTxMock,
   isApproveRequiredAdapterMock,
   EvmTokenAdapterMock,
@@ -35,6 +37,8 @@ const {
   const tryGetMsgIdMock = vi.fn(() => 'msg-1');
   const sendTransactionMock = vi.fn();
   const sendMultiTransactionMock = vi.fn();
+  const mockEnsureWalletOnChain = vi.fn(() => Promise.resolve());
+  const mockPreEstimateGasForEvmTxs = vi.fn(() => Promise.resolve());
   const populateApproveTxMock = vi.fn(() => Promise.resolve({ to: 'router' }));
   const isApproveRequiredAdapterMock = vi.fn(() => Promise.resolve(true));
   const EvmTokenAdapterMock = vi.fn(() => ({
@@ -57,6 +61,7 @@ const {
     tryGetExplorerAddressUrl: vi.fn(),
     tryGetExplorerTxUrl: vi.fn(),
     getProviderNetwork: vi.fn(),
+    getChainMetadata: vi.fn(() => ({ chainId: 11155111 })), // Sepolia
   } as any;
 
   const warpCoreMock = {
@@ -72,6 +77,11 @@ const {
       sendTransaction: sendTransactionMock,
       sendMultiTransaction: sendMultiTransactionMock,
     },
+    // 'ethereum' matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+    ethereum: {
+      sendTransaction: sendTransactionMock,
+      sendMultiTransaction: sendMultiTransactionMock,
+    },
   } as any;
 
   const accountsResponse = {
@@ -79,7 +89,10 @@ const {
   } as any;
 
   const activeChainsResponse = {
-    chains: { evm: { chainName: 'ethereum' } },
+    chains: {
+      evm: { chainName: 'ethereum' },
+      ethereum: { chainName: 'sepolia' }, // used when originToken.protocol === 'ethereum'
+    },
   } as any;
 
   const config = {
@@ -99,6 +112,8 @@ const {
     tryGetMsgIdMock,
     sendTransactionMock,
     sendMultiTransactionMock,
+    mockEnsureWalletOnChain,
+    mockPreEstimateGasForEvmTxs,
     populateApproveTxMock,
     isApproveRequiredAdapterMock,
     EvmTokenAdapterMock,
@@ -183,6 +198,11 @@ vi.mock('wagmi', () => ({
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: () => undefined,
+}));
+
+vi.mock('../../chains/rpcUtils', () => ({
+  ensureWalletOnChain: (...args: any[]) => mockEnsureWalletOnChain(...args),
+  preEstimateGasForEvmTxs: (...args: any[]) => mockPreEstimateGasForEvmTxs(...args),
 }));
 
 describe('useTokenTransfer', () => {
@@ -555,6 +575,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('completes transfer across multiple retries with progressive approvals (non-USDC from pruv)', async () => {
+
       // Simulates a user who:
       // 1. Approves USDC bridge fee, then stops (failure before token approval)
       // 2. Retries: USDC skipped (already approved), approves token, then stops
@@ -671,6 +692,108 @@ describe('useTokenTransfer', () => {
         0,
         TransferStatus.ConfirmedTransfer,
         expect.objectContaining({ originTxHash: '0xtransfer' }),
+      );
+    });
+  });
+
+  describe('EVM chain-switch guard (ensureWalletOnChain)', () => {
+    // Use protocol:'ethereum' to exercise the ProtocolType.Ethereum branch,
+    // which is the branch that calls ensureWalletOnChain.
+    const evmToken = {
+      protocol: 'ethereum', // matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+      symbol: 'TEST',
+      decimals: 18,
+      chainName: 'sepolia',
+      addressOrDenom: '0xtoken',
+      collateralAddressOrDenom: '0xcollateral',
+      isNft: () => false,
+      amount: vi.fn(() => ({ amount: 'raw-amount' })),
+      getConnectionForChain: vi.fn(() => ({
+        token: { addressOrDenom: '0xdest-token', protocol: 'ethereum', decimals: 18, scale: 18 },
+      })),
+    } as any;
+
+    const evmValues = {
+      origin: 'sepolia',
+      destination: 'dest-chain',
+      tokenIndex: 0,
+      amount: '1.0',
+      recipient: '0xrecipient',
+    } as any;
+
+    beforeEach(() => {
+      config.enablePruvOriginFeeUSDC = false; // skip pruv logic for these tests
+      getTokenByIndexMock.mockReturnValue(evmToken);
+      warpCoreMock.getTransferRemoteTxs.mockResolvedValue([
+        {
+          category: warpTxCategories.Transfer,
+          type: 'ethereum',
+          transaction: { to: '0xrouter' },
+        },
+      ]);
+      mockEnsureWalletOnChain.mockResolvedValue(undefined);
+      mockPreEstimateGasForEvmTxs.mockResolvedValue(undefined);
+    });
+
+    it('calls ensureWalletOnChain with wagmiConfig and the origin chainId before sending', async () => {
+      const confirm = vi
+        .fn()
+        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      // wagmiConfig is {} (from useConfig mock), chainId is 11155111 (Sepolia from getChainMetadata mock)
+      expect(mockEnsureWalletOnChain).toHaveBeenCalledWith({}, 11155111);
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(
+        0,
+        TransferStatus.ConfirmedTransfer,
+        expect.objectContaining({ originTxHash: '0xtx' }),
+      );
+    });
+
+    it('surfaces ChainMismatchError from ensureWalletOnChain as a chain mismatch toast', async () => {
+      mockEnsureWalletOnChain.mockRejectedValue(
+        new Error('ChainMismatchError: wallet did not switch'),
+      );
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(0, TransferStatus.Failed);
+      expect(toastErrorMock).toHaveBeenCalledWith('Wallet must be connected to origin chain', {
+        autoClose: 8000,
+        ariaLabel: 'Transfer Failed',
+        theme: 'colored',
+      });
+      // sendTransaction should never be reached
+      expect(sendTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('calls preEstimateGasForEvmTxs after ensureWalletOnChain succeeds', async () => {
+      const confirm = vi
+        .fn()
+        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(mockPreEstimateGasForEvmTxs).toHaveBeenCalledWith(
+        {}, // wagmiConfig
+        11155111, // chainId
+        '0xsender',
+        expect.any(Array),
       );
     });
   });

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -575,7 +575,6 @@ describe('useTokenTransfer', () => {
     });
 
     it('completes transfer across multiple retries with progressive approvals (non-USDC from pruv)', async () => {
-
       // Simulates a user who:
       // 1. Approves USDC bridge fee, then stops (failure before token approval)
       // 2. Retries: USDC skipped (already approved), approves token, then stops
@@ -736,9 +735,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('calls ensureWalletOnChain with wagmiConfig and the origin chainId before sending', async () => {
-      const confirm = vi
-        .fn()
-        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
       sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
 
       const { result } = renderHook(() => useTokenTransfer());
@@ -778,9 +775,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('calls preEstimateGasForEvmTxs after ensureWalletOnChain succeeds', async () => {
-      const confirm = vi
-        .fn()
-        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
       sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
 
       const { result } = renderHook(() => useTokenTransfer());

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
-import { preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { ensureWalletOnChain, preEstimateGasForEvmTxs } from '../chains/rpcUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -254,6 +254,10 @@ async function executeTransfer({
     // attempt estimation through the WalletConnect connector's rpcMap.
     if (originProtocol === ProtocolType.Ethereum) {
       const chainId = multiProvider.getChainMetadata(origin).chainId as number;
+      // Ensure the wallet is on the origin chain before submitting. WalletConnect
+      // with MetaMask mobile can take >2 s to propagate a chain switch back to
+      // wagmi's store, so we poll until the change is confirmed (up to 30 s).
+      await ensureWalletOnChain(wagmiConfig, chainId);
       await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, txs as any);
     }
 


### PR DESCRIPTION
## Problem

When connecting with MetaMask mobile via WalletConnect and initiating a transfer, users intermittently see:

> **"Wallet must be connected to origin chain"**

even after having the correct chain selected in MetaMask.

The root cause is in `@hyperlane-xyz/widgets`' EVM transaction handler. Before sending each transaction it calls wagmi's `switchChain`, then waits a hardcoded **2 seconds**, and immediately checks `getAccount().chain.id` against the expected chain ID. With MetaMask mobile over WalletConnect, the `chainChanged` event relayed back through the WalletConnect session can take **several seconds longer than 2 s** to propagate into the wagmi store. The chain-ID assertion therefore fails and throws a `ChainMismatchError`, which surfaces as the unhelpful toast above.


https://github.com/user-attachments/assets/7e3bbb50-a9aa-436d-aac8-0518b242a65d

## Fix

Two new helpers are added to `src/features/chains/rpcUtils.ts`:

- **`waitForChainSwitch(wagmiConfig, chainId, timeoutMs?)`** — polls `getAccount().chainId` every 500 ms until it matches the expected chain, or throws a `ChainMismatchError` after the timeout (default 30 s).
- **`ensureWalletOnChain(wagmiConfig, chainId)`** — calls `switchChain` if the wallet is not already on the target chain, then delegates to `waitForChainSwitch`. Any `switchChain` rejection (e.g. user dismissal) is swallowed; `waitForChainSwitch` will surface a clear error if the chain never updates.

`ensureWalletOnChain` is called in `executeTransfer` (inside `useTokenTransfer.ts`) **before** the transaction loop for every EVM transfer. By the time the widgets layer runs its own 2-second check, the wagmi store is already confirmed to reflect the correct chain.

## Behaviour after the fix

- Users on MetaMask mobile via WalletConnect can transfer without hitting the false chain-mismatch error.
- If the wallet genuinely never switches (e.g. user ignores the prompt for 30 s), the same "Wallet must be connected to origin chain" toast is shown — but only after a real timeout, not a race condition.
- No change for desktop wallets or non-EVM chains.

after fix


https://github.com/user-attachments/assets/0900e5f6-93ea-4ffd-bd18-396f669ed606

