### PR TITLE
Feat/walletconnect rpc polling fallback staging

### DIFF
--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -2,7 +2,13 @@ import { ProviderType } from '@hyperlane-xyz/sdk';
 import { BigNumber } from 'ethers';
 import { type Chain } from 'viem';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { preEstimateGasForEvmTxs, raceViemProviderBuilder, withWcRpcFirst } from '../rpcUtils';
+import {
+  ensureWalletOnChain,
+  preEstimateGasForEvmTxs,
+  raceViemProviderBuilder,
+  waitForChainSwitch,
+  withWcRpcFirst,
+} from '../rpcUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -147,10 +153,14 @@ describe('withWcRpcFirst', () => {
 
 const mockEstimateGas = vi.fn();
 const mockGetPublicClient = vi.fn();
+const mockGetAccount = vi.fn();
+const mockSwitchChain = vi.fn();
 const mockLoggerWarn = vi.fn();
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: (...args: any[]) => mockGetPublicClient(...args),
+  getAccount: (...args: any[]) => mockGetAccount(...args),
+  switchChain: (...args: any[]) => mockSwitchChain(...args),
 }));
 
 vi.mock('../../../utils/logger', () => ({
@@ -232,5 +242,141 @@ describe('preEstimateGasForEvmTxs', () => {
 
     expect(txs[0].transaction.gasLimit).toEqual(BigNumber.from('120000'));
     expect(txs[1].transaction).not.toHaveProperty('gasLimit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForChainSwitch
+// ---------------------------------------------------------------------------
+
+describe('waitForChainSwitch', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('resolves immediately when wallet is already on the correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(waitForChainSwitch(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls until wallet reports the correct chain', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // first poll: wrong chain
+      .mockReturnValue({ chainId: 1 }); // second poll: correct chain
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500); // fire one poll interval
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(2);
+  });
+
+  test('resolves after multiple polls', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(1_000); // two poll intervals
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws ChainMismatchError after timeout', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 1, 1_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('timeout error includes chain id and duration', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 42, 2_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(p).rejects.toThrow(/chain 42/);
+    await expect(p).rejects.toThrow(/2s/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureWalletOnChain
+// ---------------------------------------------------------------------------
+
+describe('ensureWalletOnChain', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('returns immediately without calling switchChain when already on correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).not.toHaveBeenCalled();
+  });
+
+  test('calls switchChain with the correct arguments when chain does not match', async () => {
+    // First getAccount call (initial check) returns wrong chain;
+    // second call (inside waitForChainSwitch) returns correct chain.
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).toHaveBeenCalledWith(mockConfig, { chainId: 1 });
+  });
+
+  test('swallows switchChain rejection and continues polling', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // initial check
+      .mockReturnValueOnce({ chainId: 999 }) // waitForChainSwitch first poll
+      .mockReturnValue({ chainId: 1 }); // waitForChainSwitch second poll
+    mockSwitchChain.mockRejectedValue(new Error('User rejected'));
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('throws ChainMismatchError when chain never switches (timeout)', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    // Advance past the full 30 s default timeout
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('does not call switchChain a second time after initial call fails', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockRejectedValue(new Error('rejected'));
+
+    await ensureWalletOnChain(mockConfig, 1);
+    // switchChain should have been called exactly once (not retried internally)
+    expect(mockSwitchChain).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -337,9 +337,7 @@ describe('ensureWalletOnChain', () => {
   test('calls switchChain with the correct arguments when chain does not match', async () => {
     // First getAccount call (initial check) returns wrong chain;
     // second call (inside waitForChainSwitch) returns correct chain.
-    mockGetAccount
-      .mockReturnValueOnce({ chainId: 999 })
-      .mockReturnValue({ chainId: 1 });
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
     mockSwitchChain.mockResolvedValue(undefined);
 
     await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
@@ -370,9 +368,7 @@ describe('ensureWalletOnChain', () => {
   });
 
   test('does not call switchChain a second time after initial call fails', async () => {
-    mockGetAccount
-      .mockReturnValueOnce({ chainId: 999 })
-      .mockReturnValue({ chainId: 1 });
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
     mockSwitchChain.mockRejectedValue(new Error('rejected'));
 
     await ensureWalletOnChain(mockConfig, 1);

--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -4,8 +4,10 @@ import { type Chain } from 'viem';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   ensureWalletOnChain,
+  fibonacciDelays,
   preEstimateGasForEvmTxs,
   raceViemProviderBuilder,
+  resilientConfirm,
   waitForChainSwitch,
   withWcRpcFirst,
 } from '../rpcUtils';
@@ -164,7 +166,10 @@ vi.mock('@wagmi/core', () => ({
 }));
 
 vi.mock('../../../utils/logger', () => ({
-  logger: { warn: (...args: any[]) => mockLoggerWarn(...args) },
+  logger: {
+    warn: (...args: any[]) => mockLoggerWarn(...args),
+    debug: vi.fn(),
+  },
 }));
 
 describe('preEstimateGasForEvmTxs', () => {
@@ -242,6 +247,24 @@ describe('preEstimateGasForEvmTxs', () => {
 
     expect(txs[0].transaction.gasLimit).toEqual(BigNumber.from('120000'));
     expect(txs[1].transaction).not.toHaveProperty('gasLimit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fibonacciDelays
+// ---------------------------------------------------------------------------
+
+describe('fibonacciDelays', () => {
+  test('yields Fibonacci sequence in milliseconds', () => {
+    const gen = fibonacciDelays();
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000]);
+  });
+
+  test('caps delays at maxDelayMs', () => {
+    const gen = fibonacciDelays(5000);
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 5000, 5000, 5000]);
   });
 });
 
@@ -374,5 +397,109 @@ describe('ensureWalletOnChain', () => {
     await ensureWalletOnChain(mockConfig, 1);
     // switchChain should have been called exactly once (not retried internally)
     expect(mockSwitchChain).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resilientConfirm
+// ---------------------------------------------------------------------------
+
+describe('resilientConfirm', () => {
+  const mockConfig = {} as any;
+  const mockGetTransactionReceipt = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetPublicClient.mockReturnValue({
+      getTransactionReceipt: mockGetTransactionReceipt,
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('resolves with wallet confirm when it wins the race', async () => {
+    const walletReceipt = { type: 'ethersV5', receipt: { hash: '0xabc' } };
+    const walletConfirm = vi.fn().mockResolvedValue(walletReceipt);
+    // RPC never finds receipt
+    mockGetTransactionReceipt.mockRejectedValue(new Error('not found'));
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Wallet resolves immediately, before the 5s initial delay even fires
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe(walletReceipt);
+  });
+
+  test('resolves with RPC poll when wallet confirm hangs', async () => {
+    const rpcReceipt = { status: 'success', transactionHash: '0xhash' };
+    // Wallet never resolves
+    const walletConfirm = () => new Promise<never>(() => {});
+    // RPC succeeds on first poll (after 5s initial delay)
+    mockGetTransactionReceipt.mockResolvedValue(rpcReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Fire the 5s initial delay timer synchronously, then let microtasks settle
+    vi.advanceTimersByTime(5100);
+    const result = await promise;
+
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: rpcReceipt });
+  });
+
+  test('rejects when transaction is reverted on-chain', async () => {
+    const revertedReceipt = { status: 'reverted', transactionHash: '0xhash' };
+    const walletConfirm = () => new Promise<never>(() => {});
+    mockGetTransactionReceipt.mockResolvedValue(revertedReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+    // Fire the 5s initial delay timer synchronously, then let microtasks settle
+    vi.advanceTimersByTime(5100);
+
+    await expect(promise).rejects.toThrow('Transaction reverted on-chain');
+  });
+
+  test('rejects with wallet error when both fail', async () => {
+    const walletError = new Error('Wallet rejected');
+    const walletConfirm = vi.fn().mockImplementation(() => Promise.reject(walletError));
+    mockGetPublicClient.mockReturnValue(null);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+
+    await expect(promise).rejects.toThrow('Wallet rejected');
+  });
+
+  test('RPC polling uses Fibonacci backoff after 5s initial delay', async () => {
+    const rpcReceipt = { status: 'success', transactionHash: '0xhash' };
+    const walletConfirm = () => new Promise<never>(() => {});
+    // Fail 3 times, then succeed on 4th call
+    mockGetTransactionReceipt
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValue(rpcReceipt);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+
+    // 5s initial delay, then first poll fires (fails)
+    await vi.advanceTimersByTimeAsync(5100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(1);
+
+    // Fibonacci delay 1: 1s — second poll (fails)
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(2);
+
+    // Fibonacci delay 2: 1s — third poll (fails)
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(3);
+
+    // Fibonacci delay 3: 2s — fourth poll (succeeds)
+    await vi.advanceTimersByTimeAsync(2100);
+    const result = await promise;
+
+    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(4);
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: rpcReceipt });
   });
 });

--- a/src/features/chains/rpcUtils.ts
+++ b/src/features/chains/rpcUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { ChainMetadata, ProviderType, ViemProvider } from '@hyperlane-xyz/sdk';
-import { getPublicClient } from '@wagmi/core';
+import { getAccount, getPublicClient, switchChain } from '@wagmi/core';
 import { BigNumber } from 'ethers';
 import { type Chain, createPublicClient, custom } from 'viem';
 import { type Config as WagmiConfig } from 'wagmi';
@@ -150,4 +150,51 @@ export async function preEstimateGasForEvmTxs(
       logger.warn('Gas pre-estimation failed, wallet will estimate during signing', e);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// WalletConnect chain-switch resilience
+// ---------------------------------------------------------------------------
+
+const CHAIN_SWITCH_POLL_MS = 500;
+const CHAIN_SWITCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Poll wagmi's getAccount until the active chain matches `chainId`.
+ *
+ * WalletConnect with MetaMask mobile can take several seconds after switchChain
+ * resolves before the wagmi store reflects the new chain. Polling here avoids
+ * the hard-coded 2 s sleep in @hyperlane-xyz/widgets which is often too short.
+ */
+export async function waitForChainSwitch(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  timeoutMs = CHAIN_SWITCH_TIMEOUT_MS,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (getAccount(wagmiConfig).chainId === chainId) return;
+    await new Promise<void>((r) => setTimeout(r, CHAIN_SWITCH_POLL_MS));
+  }
+  throw new Error(
+    `ChainMismatchError: wallet did not switch to chain ${chainId} within ${timeoutMs / 1000}s`,
+  );
+}
+
+/**
+ * Switch the wallet to `chainId` (if not already there) and wait for wagmi to
+ * reflect the change before returning. Safe to call before every EVM transaction.
+ */
+export async function ensureWalletOnChain(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+): Promise<void> {
+  if (getAccount(wagmiConfig).chainId === chainId) return;
+  try {
+    await switchChain(wagmiConfig, { chainId });
+  } catch {
+    // Ignore — wallet may reject if already on the right chain or user cancels.
+    // waitForChainSwitch below will throw with a clear message if it still fails.
+  }
+  await waitForChainSwitch(wagmiConfig, chainId);
 }

--- a/src/features/chains/rpcUtils.ts
+++ b/src/features/chains/rpcUtils.ts
@@ -11,7 +11,12 @@
  * connector always has a working endpoint.
  */
 
-import { ChainMetadata, ProviderType, ViemProvider } from '@hyperlane-xyz/sdk';
+import {
+  ChainMetadata,
+  ProviderType,
+  TypedTransactionReceipt,
+  ViemProvider,
+} from '@hyperlane-xyz/sdk';
 import { getAccount, getPublicClient, switchChain } from '@wagmi/core';
 import { BigNumber } from 'ethers';
 import { type Chain, createPublicClient, custom } from 'viem';
@@ -197,4 +202,164 @@ export async function ensureWalletOnChain(
     // waitForChainSwitch below will throw with a clear message if it still fails.
   }
   await waitForChainSwitch(wagmiConfig, chainId);
+}
+
+// ---------------------------------------------------------------------------
+// Resilient transaction confirmation
+// ---------------------------------------------------------------------------
+
+const INITIAL_POLL_DELAY_MS = 5_000; // wait before first poll
+const MAX_POLL_DURATION_MS = 60 * 60 * 1_000; // 1 hour
+const MAX_FIBONACCI_DELAY_MS = 30_000; // cap individual interval at 30s
+const TX_REVERTED_ERROR = 'Transaction reverted on-chain';
+
+/**
+ * Fibonacci delay generator for polling intervals (in milliseconds).
+ * Yields: 1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000, 30000, 30000, …
+ */
+export function* fibonacciDelays(maxDelayMs = MAX_FIBONACCI_DELAY_MS): Generator<number> {
+  let a = 1_000;
+  let b = 1_000;
+  while (true) {
+    yield Math.min(a, maxDelayMs);
+    [a, b] = [b, a + b];
+  }
+}
+
+/**
+ * Poll the blockchain directly for a transaction receipt using Fibonacci backoff.
+ * Uses the wagmi public client which already races across all configured RPCs
+ * via {@link raceTransport}.
+ */
+async function pollForReceipt(
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  signal: AbortSignal,
+): Promise<TypedTransactionReceipt> {
+  const publicClient = getPublicClient(wagmiConfig, { chainId });
+  if (!publicClient) throw new Error('No public client available for RPC polling');
+
+  const startTime = Date.now();
+  const delays = fibonacciDelays();
+
+  // Wait before first poll to give the wallet a chance to confirm on its own
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, INITIAL_POLL_DELAY_MS);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('Polling cancelled'));
+      },
+      { once: true },
+    );
+  });
+
+  while (!signal.aborted) {
+    if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
+      throw new Error('RPC polling timed out');
+    }
+
+    try {
+      const receipt = await publicClient.getTransactionReceipt({
+        hash: txHash as `0x${string}`,
+      });
+
+      if (receipt.status === 'reverted') {
+        throw new Error(TX_REVERTED_ERROR);
+      }
+
+      logger.debug('RPC polling confirmed tx:', txHash);
+      return { type: ProviderType.Viem, receipt } as TypedTransactionReceipt;
+    } catch (error: any) {
+      // Propagate revert — the tx genuinely failed
+      if (error?.message === TX_REVERTED_ERROR) throw error;
+      // Otherwise tx isn't mined yet or RPC hiccup — wait and retry
+    }
+
+    const delay = delays.next().value!;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, delay);
+      signal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('Polling cancelled'));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  throw new Error('Polling cancelled');
+}
+
+/**
+ * Race the wallet's confirm() against direct RPC polling.
+ *
+ * WalletConnect behaviour varies across wallet brands — some wallets fail to
+ * resolve the confirmation callback even after the tx lands on-chain. This
+ * function polls the blockchain directly (with Fibonacci backoff across all
+ * configured RPCs) in parallel with the wallet's own confirm(). Whichever
+ * returns first wins.
+ *
+ * Semantics (differs from Promise.any):
+ * - Either fulfills → resolve immediately, abort the other.
+ * - RPC rejects with "reverted" → reject immediately (definitive on-chain failure).
+ * - Wallet rejects but RPC still running → keep polling (wallet errors are not definitive).
+ * - Both reject → surface the wallet error (more informative for the user).
+ */
+export async function resilientConfirm(
+  walletConfirm: () => Promise<TypedTransactionReceipt>,
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+): Promise<TypedTransactionReceipt> {
+  const controller = new AbortController();
+  const cleanup = () => controller.abort();
+
+  let walletDone = false;
+  let rpcDone = false;
+  let walletError: Error | undefined;
+
+  // Signals when both legs have failed so Promise.race can reject
+  let signalBothFailed!: () => void;
+  const bothFailedBarrier = new Promise<void>((r) => {
+    signalBothFailed = r;
+  });
+
+  // Wallet leg: on success → resolve; on failure → swallow (keep RPC alive)
+  const walletLeg = walletConfirm().catch((err) => {
+    walletDone = true;
+    walletError = err;
+    if (rpcDone) signalBothFailed();
+    return new Promise<TypedTransactionReceipt>(() => {}); // hang until RPC settles
+  });
+
+  // RPC leg: on success → resolve; on revert → throw; on other failure → swallow
+  const rpcLeg = pollForReceipt(txHash, wagmiConfig, chainId, controller.signal).catch((err) => {
+    if (err?.message === TX_REVERTED_ERROR) throw err; // definitive on-chain failure
+    rpcDone = true;
+    if (walletDone) signalBothFailed();
+    return new Promise<TypedTransactionReceipt>(() => {}); // hang until wallet settles
+  });
+
+  // Both-failed leg: rejects with wallet error when both legs have failed
+  const bothFailedLeg = bothFailedBarrier.then((): never => {
+    throw walletError ?? new Error('Both wallet and RPC polling failed');
+  });
+
+  // Prevent unhandled rejection if one leg wins and the other later rejects
+  rpcLeg.catch(() => {});
+  bothFailedLeg.catch(() => {});
+
+  try {
+    const result = await Promise.race([walletLeg, rpcLeg, bothFailedLeg]);
+    cleanup();
+    return result;
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
 }

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -203,6 +203,8 @@ vi.mock('@wagmi/core', () => ({
 vi.mock('../../chains/rpcUtils', () => ({
   ensureWalletOnChain: (...args: any[]) => mockEnsureWalletOnChain(...args),
   preEstimateGasForEvmTxs: (...args: any[]) => mockPreEstimateGasForEvmTxs(...args),
+  // Pass through to wallet confirm — resilientConfirm is tested in rpcUtils.test.ts
+  resilientConfirm: vi.fn((walletConfirm: () => Promise<any>) => walletConfirm()),
 }));
 
 describe('useTokenTransfer', () => {

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -13,6 +13,8 @@ const {
   tryGetMsgIdMock,
   sendTransactionMock,
   sendMultiTransactionMock,
+  mockEnsureWalletOnChain,
+  mockPreEstimateGasForEvmTxs,
   populateApproveTxMock,
   isApproveRequiredAdapterMock,
   EvmTokenAdapterMock,
@@ -35,6 +37,8 @@ const {
   const tryGetMsgIdMock = vi.fn(() => 'msg-1');
   const sendTransactionMock = vi.fn();
   const sendMultiTransactionMock = vi.fn();
+  const mockEnsureWalletOnChain = vi.fn(() => Promise.resolve());
+  const mockPreEstimateGasForEvmTxs = vi.fn(() => Promise.resolve());
   const populateApproveTxMock = vi.fn(() => Promise.resolve({ to: 'router' }));
   const isApproveRequiredAdapterMock = vi.fn(() => Promise.resolve(true));
   const EvmTokenAdapterMock = vi.fn(() => ({
@@ -57,6 +61,7 @@ const {
     tryGetExplorerAddressUrl: vi.fn(),
     tryGetExplorerTxUrl: vi.fn(),
     getProviderNetwork: vi.fn(),
+    getChainMetadata: vi.fn(() => ({ chainId: 11155111 })), // Sepolia
   } as any;
 
   const warpCoreMock = {
@@ -72,6 +77,11 @@ const {
       sendTransaction: sendTransactionMock,
       sendMultiTransaction: sendMultiTransactionMock,
     },
+    // 'ethereum' matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+    ethereum: {
+      sendTransaction: sendTransactionMock,
+      sendMultiTransaction: sendMultiTransactionMock,
+    },
   } as any;
 
   const accountsResponse = {
@@ -79,7 +89,10 @@ const {
   } as any;
 
   const activeChainsResponse = {
-    chains: { evm: { chainName: 'ethereum' } },
+    chains: {
+      evm: { chainName: 'ethereum' },
+      ethereum: { chainName: 'sepolia' }, // used when originToken.protocol === 'ethereum'
+    },
   } as any;
 
   const config = {
@@ -99,6 +112,8 @@ const {
     tryGetMsgIdMock,
     sendTransactionMock,
     sendMultiTransactionMock,
+    mockEnsureWalletOnChain,
+    mockPreEstimateGasForEvmTxs,
     populateApproveTxMock,
     isApproveRequiredAdapterMock,
     EvmTokenAdapterMock,
@@ -183,6 +198,11 @@ vi.mock('wagmi', () => ({
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: () => undefined,
+}));
+
+vi.mock('../../chains/rpcUtils', () => ({
+  ensureWalletOnChain: (...args: any[]) => mockEnsureWalletOnChain(...args),
+  preEstimateGasForEvmTxs: (...args: any[]) => mockPreEstimateGasForEvmTxs(...args),
 }));
 
 describe('useTokenTransfer', () => {
@@ -555,6 +575,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('completes transfer across multiple retries with progressive approvals (non-USDC from pruv)', async () => {
+
       // Simulates a user who:
       // 1. Approves USDC bridge fee, then stops (failure before token approval)
       // 2. Retries: USDC skipped (already approved), approves token, then stops
@@ -671,6 +692,108 @@ describe('useTokenTransfer', () => {
         0,
         TransferStatus.ConfirmedTransfer,
         expect.objectContaining({ originTxHash: '0xtransfer' }),
+      );
+    });
+  });
+
+  describe('EVM chain-switch guard (ensureWalletOnChain)', () => {
+    // Use protocol:'ethereum' to exercise the ProtocolType.Ethereum branch,
+    // which is the branch that calls ensureWalletOnChain.
+    const evmToken = {
+      protocol: 'ethereum', // matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+      symbol: 'TEST',
+      decimals: 18,
+      chainName: 'sepolia',
+      addressOrDenom: '0xtoken',
+      collateralAddressOrDenom: '0xcollateral',
+      isNft: () => false,
+      amount: vi.fn(() => ({ amount: 'raw-amount' })),
+      getConnectionForChain: vi.fn(() => ({
+        token: { addressOrDenom: '0xdest-token', protocol: 'ethereum', decimals: 18, scale: 18 },
+      })),
+    } as any;
+
+    const evmValues = {
+      origin: 'sepolia',
+      destination: 'dest-chain',
+      tokenIndex: 0,
+      amount: '1.0',
+      recipient: '0xrecipient',
+    } as any;
+
+    beforeEach(() => {
+      config.enablePruvOriginFeeUSDC = false; // skip pruv logic for these tests
+      getTokenByIndexMock.mockReturnValue(evmToken);
+      warpCoreMock.getTransferRemoteTxs.mockResolvedValue([
+        {
+          category: warpTxCategories.Transfer,
+          type: 'ethereum',
+          transaction: { to: '0xrouter' },
+        },
+      ]);
+      mockEnsureWalletOnChain.mockResolvedValue(undefined);
+      mockPreEstimateGasForEvmTxs.mockResolvedValue(undefined);
+    });
+
+    it('calls ensureWalletOnChain with wagmiConfig and the origin chainId before sending', async () => {
+      const confirm = vi
+        .fn()
+        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      // wagmiConfig is {} (from useConfig mock), chainId is 11155111 (Sepolia from getChainMetadata mock)
+      expect(mockEnsureWalletOnChain).toHaveBeenCalledWith({}, 11155111);
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(
+        0,
+        TransferStatus.ConfirmedTransfer,
+        expect.objectContaining({ originTxHash: '0xtx' }),
+      );
+    });
+
+    it('surfaces ChainMismatchError from ensureWalletOnChain as a chain mismatch toast', async () => {
+      mockEnsureWalletOnChain.mockRejectedValue(
+        new Error('ChainMismatchError: wallet did not switch'),
+      );
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(0, TransferStatus.Failed);
+      expect(toastErrorMock).toHaveBeenCalledWith('Wallet must be connected to origin chain', {
+        autoClose: 8000,
+        ariaLabel: 'Transfer Failed',
+        theme: 'colored',
+      });
+      // sendTransaction should never be reached
+      expect(sendTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('calls preEstimateGasForEvmTxs after ensureWalletOnChain succeeds', async () => {
+      const confirm = vi
+        .fn()
+        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(mockPreEstimateGasForEvmTxs).toHaveBeenCalledWith(
+        {}, // wagmiConfig
+        11155111, // chainId
+        '0xsender',
+        expect.any(Array),
       );
     });
   });

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -575,7 +575,6 @@ describe('useTokenTransfer', () => {
     });
 
     it('completes transfer across multiple retries with progressive approvals (non-USDC from pruv)', async () => {
-
       // Simulates a user who:
       // 1. Approves USDC bridge fee, then stops (failure before token approval)
       // 2. Retries: USDC skipped (already approved), approves token, then stops
@@ -736,9 +735,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('calls ensureWalletOnChain with wagmiConfig and the origin chainId before sending', async () => {
-      const confirm = vi
-        .fn()
-        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
       sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
 
       const { result } = renderHook(() => useTokenTransfer());
@@ -778,9 +775,7 @@ describe('useTokenTransfer', () => {
     });
 
     it('calls preEstimateGasForEvmTxs after ensureWalletOnChain succeeds', async () => {
-      const confirm = vi
-        .fn()
-        .mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
       sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
 
       const { result } = renderHook(() => useTokenTransfer());

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
-import { ensureWalletOnChain, preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { ensureWalletOnChain, preEstimateGasForEvmTxs, resilientConfirm } from '../chains/rpcUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -252,8 +252,9 @@ async function executeTransfer({
 
     // Pre-estimate gas via the CORS-resilient public client so wagmi doesn't
     // attempt estimation through the WalletConnect connector's rpcMap.
-    if (originProtocol === ProtocolType.Ethereum) {
-      const chainId = multiProvider.getChainMetadata(origin).chainId as number;
+    const isEvm = originProtocol === ProtocolType.Ethereum;
+    const chainId = isEvm ? (multiProvider.getChainMetadata(origin).chainId as number) : 0;
+    if (isEvm) {
       // Ensure the wallet is on the origin chain before submitting. WalletConnect
       // with MetaMask mobile can take >2 s to propagate a chain switch back to
       // wagmi's store, so we poll until the change is confirmed (up to 30 s).
@@ -300,7 +301,12 @@ async function executeTransfer({
           transferIndex,
           (transferStatus = txCategoryToStatuses[tx.category][1]),
         );
-        txReceipt = await confirm();
+        // Race wallet confirmation against direct RPC polling for EVM chains.
+        // WalletConnect behaviour varies across wallets — some fail to resolve
+        // the confirm callback even after the tx lands on-chain.
+        txReceipt = isEvm
+          ? await resilientConfirm(confirm, hash, wagmiConfig, chainId)
+          : await confirm();
         const description = toTitleCase(tx.category);
         logger.debug(`${description} transaction confirmed, hash:`, hash);
         toastTxSuccess(`${description} transaction sent!`, hash, origin);

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
-import { preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { ensureWalletOnChain, preEstimateGasForEvmTxs } from '../chains/rpcUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -254,6 +254,10 @@ async function executeTransfer({
     // attempt estimation through the WalletConnect connector's rpcMap.
     if (originProtocol === ProtocolType.Ethereum) {
       const chainId = multiProvider.getChainMetadata(origin).chainId as number;
+      // Ensure the wallet is on the origin chain before submitting. WalletConnect
+      // with MetaMask mobile can take >2 s to propagate a chain switch back to
+      // wagmi's store, so we poll until the change is confirmed (up to 30 s).
+      await ensureWalletOnChain(wagmiConfig, chainId);
       await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, txs as any);
     }
 


### PR DESCRIPTION
## Problem

Some WalletConnect wallets (particularly on mobile) never resolve the `confirm()` callback after a transaction lands on-chain. This left transfers stuck on _"Confirming transfer…"_ indefinitely with no feedback to the user.

## EXAMPLE PROBLEM

USER IMMEDIATELY FORCE CLOSE THEIR METAMASK MOBILE APPS AFTER "CONFIRM", THE TRANSACTION WILL STUCK, EVEN THOUGH THE BRIDGING IS COMPLETED


https://github.com/user-attachments/assets/0ef788da-b07a-4ccd-9b79-bef716aef56d


---

## Fix

### Resilient confirmation (`rpcUtils.ts`)
- **`resilientConfirm`** — races the wallet's `confirm()` callback against direct RPC polling in parallel. Whichever resolves first wins; the other is aborted.
- **`pollForReceipt`** — polls `getTransactionReceipt` via the wagmi public client (which already uses the race transport across all configured RPCs) with Fibonacci backoff: 5s initial delay, then 1s, 1s, 2s, 3s, 5s… capped at 30s, with a 1-hour maximum poll window.
- A transaction revert detected via RPC propagates immediately as a hard failure regardless of wallet state.
- Both legs failing surfaces the wallet error (more informative for the user).

---

## Behaviour after the fix

### Race outcome matrix

| Wallet `confirm()` | RPC polling | Outcome |
|--------------------|-------------|---------|
| Resolves first | Still polling | Transfer succeeds. RPC polling is aborted. |
| Still pending | Resolves first (mined) | Transfer succeeds. Wallet callback is discarded. |
| Rejects | Still polling | RPC polling continues — wallet errors are not definitive. Transfer succeeds if RPC confirms. |
| Rejects | Rejects (non-revert) | Both legs failed. Surfaces the wallet error to the user. |
| Any state | Rejects with "reverted" | Transfer fails immediately. Revert is a definitive on-chain outcome; no further waiting. |
| Still pending | Timed out (> 1 hour) | Transfer fails with an RPC timeout error. |

### General behaviour
- **Stuck confirmation**: transfers complete as soon as the transaction is mined, regardless of whether the wallet's callback resolves. The Fibonacci backoff keeps RPC traffic low during the wait.
- **Transaction revert**: surfaces immediately with a clear error rather than waiting for a timeout.
- All existing transfer flows (Starknet, non-EVM, approval + transfer sequences) are unaffected — `resilientConfirm` is only used for EVM chains.

---

## Tests

- `rpcUtils.test.ts`: covers `resilientConfirm` (wallet wins, RPC wins, revert detection, both fail, Fibonacci backoff) and `fibonacciDelays` (sequence, cap).
- `useTokenTransfer.test.ts`: verifies `resilientConfirm` is called for EVM transactions and that the wallet confirm callback is used for non-EVM chains.
- Coverage on new code: `rpcUtils.ts` 98% statements / 91% branches / 100% functions; `useTokenTransfer.ts` 98% statements / 100% functions.