### PR TITLE
feat: Safe wallet support via event-based tx confirmation

### DIFF
--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -164,7 +164,10 @@ vi.mock('@wagmi/core', () => ({
 }));
 
 vi.mock('../../../utils/logger', () => ({
-  logger: { warn: (...args: any[]) => mockLoggerWarn(...args) },
+  logger: {
+    warn: (...args: any[]) => mockLoggerWarn(...args),
+    debug: vi.fn(),
+  },
 }));
 
 describe('preEstimateGasForEvmTxs', () => {

--- a/src/features/chains/__tests__/rpcUtils.test.ts
+++ b/src/features/chains/__tests__/rpcUtils.test.ts
@@ -2,7 +2,13 @@ import { ProviderType } from '@hyperlane-xyz/sdk';
 import { BigNumber } from 'ethers';
 import { type Chain } from 'viem';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { preEstimateGasForEvmTxs, raceViemProviderBuilder, withWcRpcFirst } from '../rpcUtils';
+import {
+  ensureWalletOnChain,
+  preEstimateGasForEvmTxs,
+  raceViemProviderBuilder,
+  waitForChainSwitch,
+  withWcRpcFirst,
+} from '../rpcUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -147,10 +153,14 @@ describe('withWcRpcFirst', () => {
 
 const mockEstimateGas = vi.fn();
 const mockGetPublicClient = vi.fn();
+const mockGetAccount = vi.fn();
+const mockSwitchChain = vi.fn();
 const mockLoggerWarn = vi.fn();
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: (...args: any[]) => mockGetPublicClient(...args),
+  getAccount: (...args: any[]) => mockGetAccount(...args),
+  switchChain: (...args: any[]) => mockSwitchChain(...args),
 }));
 
 vi.mock('../../../utils/logger', () => ({
@@ -232,5 +242,137 @@ describe('preEstimateGasForEvmTxs', () => {
 
     expect(txs[0].transaction.gasLimit).toEqual(BigNumber.from('120000'));
     expect(txs[1].transaction).not.toHaveProperty('gasLimit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForChainSwitch
+// ---------------------------------------------------------------------------
+
+describe('waitForChainSwitch', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('resolves immediately when wallet is already on the correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(waitForChainSwitch(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls until wallet reports the correct chain', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // first poll: wrong chain
+      .mockReturnValue({ chainId: 1 }); // second poll: correct chain
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500); // fire one poll interval
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(2);
+  });
+
+  test('resolves after multiple polls', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValueOnce({ chainId: 999 })
+      .mockReturnValue({ chainId: 1 });
+
+    const p = waitForChainSwitch(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(1_000); // two poll intervals
+    await expect(p).resolves.toBeUndefined();
+    expect(mockGetAccount).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws ChainMismatchError after timeout', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 1, 1_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('timeout error includes chain id and duration', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+
+    const p = waitForChainSwitch(mockConfig, 42, 2_000);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(p).rejects.toThrow(/chain 42/);
+    await expect(p).rejects.toThrow(/2s/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureWalletOnChain
+// ---------------------------------------------------------------------------
+
+describe('ensureWalletOnChain', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('returns immediately without calling switchChain when already on correct chain', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 1 });
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).not.toHaveBeenCalled();
+  });
+
+  test('calls switchChain with the correct arguments when chain does not match', async () => {
+    // First getAccount call (initial check) returns wrong chain;
+    // second call (inside waitForChainSwitch) returns correct chain.
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    await expect(ensureWalletOnChain(mockConfig, 1)).resolves.toBeUndefined();
+    expect(mockSwitchChain).toHaveBeenCalledWith(mockConfig, { chainId: 1 });
+  });
+
+  test('swallows switchChain rejection and continues polling', async () => {
+    mockGetAccount
+      .mockReturnValueOnce({ chainId: 999 }) // initial check
+      .mockReturnValueOnce({ chainId: 999 }) // waitForChainSwitch first poll
+      .mockReturnValue({ chainId: 1 }); // waitForChainSwitch second poll
+    mockSwitchChain.mockRejectedValue(new Error('User rejected'));
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('throws ChainMismatchError when chain never switches (timeout)', async () => {
+    mockGetAccount.mockReturnValue({ chainId: 999 });
+    mockSwitchChain.mockResolvedValue(undefined);
+
+    const p = ensureWalletOnChain(mockConfig, 1);
+    p.catch(() => {}); // prevent unhandled rejection while timers advance
+    // Advance past the full 30 s default timeout
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expect(p).rejects.toThrow('ChainMismatchError');
+  });
+
+  test('does not call switchChain a second time after initial call fails', async () => {
+    mockGetAccount.mockReturnValueOnce({ chainId: 999 }).mockReturnValue({ chainId: 1 });
+    mockSwitchChain.mockRejectedValue(new Error('rejected'));
+
+    await ensureWalletOnChain(mockConfig, 1);
+    // switchChain should have been called exactly once (not retried internally)
+    expect(mockSwitchChain).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/chains/__tests__/safeWalletUtils.test.ts
+++ b/src/features/chains/__tests__/safeWalletUtils.test.ts
@@ -1,0 +1,306 @@
+import { ProviderType } from '@hyperlane-xyz/sdk';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { fibonacciDelays, resilientConfirm } from '../safeWalletUtils';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetPublicClient = vi.fn();
+const mockGetTransactionReceipt = vi.fn();
+const mockGetBlockNumber = vi.fn();
+const mockGetLogs = vi.fn();
+
+vi.mock('@wagmi/core', () => ({
+  getPublicClient: (...args: any[]) => mockGetPublicClient(...args),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { warn: vi.fn(), debug: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// fibonacciDelays
+// ---------------------------------------------------------------------------
+
+describe('fibonacciDelays', () => {
+  test('yields Fibonacci sequence in milliseconds', () => {
+    const gen = fibonacciDelays();
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000]);
+  });
+
+  test('caps delays at maxDelayMs', () => {
+    const gen = fibonacciDelays(5000);
+    const values = Array.from({ length: 8 }, () => gen.next().value);
+    expect(values).toEqual([1000, 1000, 2000, 3000, 5000, 5000, 5000, 5000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resilientConfirm (non-Safe path)
+// ---------------------------------------------------------------------------
+
+describe('resilientConfirm (no Safe options)', () => {
+  const mockConfig = {} as any;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('resolves with the wallet confirm result', async () => {
+    const walletReceipt = { type: 'ethersV5', receipt: { hash: '0xabc', status: 'success' } };
+    const walletConfirm = vi.fn().mockResolvedValue(walletReceipt);
+
+    const result = await resilientConfirm(walletConfirm, '0xhash', mockConfig, 1);
+
+    expect(result).toBe(walletReceipt);
+  });
+
+  test('rejects when wallet confirm returns a reverted receipt', async () => {
+    const revertedReceipt = { type: 'ethersV5', receipt: { hash: '0xabc', status: 'reverted' } };
+    const walletConfirm = vi.fn().mockResolvedValue(revertedReceipt);
+
+    await expect(resilientConfirm(walletConfirm, '0xhash', mockConfig, 1)).rejects.toThrow(
+      'Transaction reverted on-chain',
+    );
+  });
+
+  test('rejects with wallet error when confirm throws', async () => {
+    const walletError = new Error('Wallet rejected');
+    const walletConfirm = vi.fn().mockRejectedValue(walletError);
+
+    await expect(resilientConfirm(walletConfirm, '0xhash', mockConfig, 1)).rejects.toThrow(
+      'Wallet rejected',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resilientConfirm with event-based polling (Safe wallet support)
+// ---------------------------------------------------------------------------
+
+describe('resilientConfirm with event polling (Safe wallet)', () => {
+  const mockConfig = {} as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetPublicClient.mockReturnValue({
+      getTransactionReceipt: mockGetTransactionReceipt,
+      getBlockNumber: mockGetBlockNumber,
+      getLogs: mockGetLogs,
+    } as any);
+    mockGetBlockNumber.mockResolvedValue(100n);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('event polling detects tx when hash-based polling fails (Safe wallet)', async () => {
+    const realTxHash = '0xreal_onchain_hash';
+    const onChainReceipt = { status: 'success', transactionHash: realTxHash };
+    const safeTxHash = '0xsafe_internal_hash';
+    const sender = '0xSafeAddress1234567890abcdef1234567890abcdef';
+    const contractAddress = '0xContractAddr';
+    const paddedSender = '0x' + sender.slice(2).toLowerCase().padStart(64, '0');
+
+    // Wallet never resolves (safeTxHash can't be confirmed via standard flow)
+    const walletConfirm = () => new Promise<never>(() => {});
+
+    // Hash-based polling always fails (safeTxHash not on-chain)
+    mockGetTransactionReceipt.mockImplementation(({ hash }: { hash: string }) => {
+      if (hash === safeTxHash) return Promise.reject(new Error('not found'));
+      if (hash === realTxHash) return Promise.resolve(onChainReceipt);
+      return Promise.reject(new Error('not found'));
+    });
+
+    // Event polling: no logs initially, then matching logs appear
+    mockGetLogs
+      .mockResolvedValueOnce([]) // first poll: no events yet
+      .mockResolvedValue([
+        {
+          transactionHash: realTxHash,
+          topics: [
+            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', // Transfer topic0
+            paddedSender, // from = Safe address
+          ],
+        },
+      ]);
+
+    const promise = resilientConfirm(walletConfirm, safeTxHash, mockConfig, 1, {
+      contractAddress,
+      sender,
+    });
+
+    // Advance past 15s event poll initial delay (block number captured before sleep)
+    await vi.advanceTimersByTimeAsync(15100);
+    // First getLogs call returns empty, wait fibonacci delay (1s)
+    await vi.advanceTimersByTimeAsync(1100);
+    // Second getLogs call returns matching log → receipt fetched → resolved
+
+    const result = await promise;
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: onChainReceipt });
+    // startBlock = 100n - 10n = 90n (10-block safety buffer)
+    expect(mockGetLogs).toHaveBeenCalledWith({
+      address: contractAddress,
+      fromBlock: 90n,
+      toBlock: 'latest',
+    });
+  });
+
+  test('event polling rejects on reverted tx', async () => {
+    const realTxHash = '0xreverted_hash';
+    const sender = '0xSafeAddress1234567890abcdef1234567890abcdef';
+    const paddedSender = '0x' + sender.slice(2).toLowerCase().padStart(64, '0');
+
+    const walletConfirm = () => new Promise<never>(() => {});
+    mockGetTransactionReceipt.mockImplementation(({ hash }: { hash: string }) => {
+      if (hash === '0xsafe_hash') return Promise.reject(new Error('not found'));
+      return Promise.resolve({ status: 'reverted', transactionHash: realTxHash });
+    });
+
+    mockGetLogs.mockResolvedValue([
+      {
+        transactionHash: realTxHash,
+        topics: ['0xtopic0', paddedSender],
+      },
+    ]);
+
+    const promise = resilientConfirm(walletConfirm, '0xsafe_hash', mockConfig, 1, {
+      contractAddress: '0xContract',
+      sender,
+    });
+
+    // Flush microtasks so getBlockNumber() resolves (called before sleep now),
+    // then advance timers synchronously to avoid unhandled rejection warnings
+    await vi.advanceTimersByTimeAsync(0);
+    vi.advanceTimersByTime(15200);
+
+    await expect(promise).rejects.toThrow('Transaction reverted on-chain');
+  });
+
+  test('rejects with wallet error when both legs fail', async () => {
+    const walletError = new Error('Wallet rejected by user');
+    const walletConfirm = vi.fn().mockImplementation(() => Promise.reject(walletError));
+
+    // No public client → event polling fails immediately
+    mockGetPublicClient.mockReturnValue(null);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1, {
+      contractAddress: '0xContract',
+      sender: '0xSender1234567890abcdef1234567890abcdef1234',
+    });
+
+    await expect(promise).rejects.toThrow('Wallet rejected by user');
+  });
+
+  test('detects transferRemote via Safe ExecutionSuccess when target contract has no sender-indexed events', async () => {
+    const realTxHash = '0xreal_onchain_hash';
+    const onChainReceipt = { status: 'success', transactionHash: realTxHash };
+    const safeTxHash = '0xsafe_internal_hash';
+    const sender = '0xSafeAddress1234567890abcdef1234567890abcdef';
+    const contractAddress = '0xRouterContract';
+
+    const walletConfirm = () => new Promise<never>(() => {});
+
+    // Hash-based polling always fails (safeTxHash not on-chain)
+    mockGetTransactionReceipt.mockImplementation(({ hash }: { hash: string }) => {
+      if (hash === realTxHash) return Promise.resolve(onChainReceipt);
+      return Promise.reject(new Error('not found'));
+    });
+
+    // Router emits SentTransferRemote(destination, recipient, amount) — sender NOT indexed
+    // Safe contract emits ExecutionSuccess(bytes32 indexed txHash, uint256 payment)
+    mockGetLogs.mockImplementation(({ address }: { address: string }) => {
+      if (address === contractAddress) return Promise.resolve([]); // no sender topic
+      if (address === sender)
+        return Promise.resolve([
+          {
+            transactionHash: realTxHash,
+            topics: [
+              '0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e', // ExecutionSuccess selector
+              safeTxHash, // indexed txHash = safeTxHash we received from sendTransaction
+            ],
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const promise = resilientConfirm(walletConfirm, safeTxHash, mockConfig, 1, {
+      contractAddress,
+      sender,
+    });
+
+    // After 15s initial delay the first cycle matches via senderLogs immediately
+    await vi.advanceTimersByTimeAsync(15100);
+    const result = await promise;
+
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: onChainReceipt });
+    expect(mockGetLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ address: sender, fromBlock: 90n }),
+    );
+  });
+
+  test('detects tx via Safe ExecutionSuccess when txHash is non-indexed (in data, not topics)', async () => {
+    // Kairos Safe: ExecutionSuccess(bytes32 txHash, uint256 payment) — txHash NOT indexed
+    const realTxHash = '0xreal_onchain_hash_kairos';
+    const onChainReceipt = { status: 'success', transactionHash: realTxHash };
+    const safeTxHash = '0xfebace30d802464d9ff84fc97c5d40f950521ce8aee1602fdf91cb41b576e055';
+    const sender = '0x1e4bbdef691b9fa30b9365948ccd04fd66d3e5f0';
+    const contractAddress = '0x8fe41adb2890df3d591160052fb0e502e4f07f11'; // warp router
+
+    const walletConfirm = () => new Promise<never>(() => {});
+    mockGetTransactionReceipt.mockImplementation(({ hash }: { hash: string }) => {
+      if (hash === realTxHash) return Promise.resolve(onChainReceipt);
+      return Promise.reject(new Error('not found'));
+    });
+
+    mockGetLogs.mockImplementation(({ address }: { address: string }) => {
+      if (address === contractAddress) return Promise.resolve([]); // no sender-indexed events
+      if (address === sender)
+        return Promise.resolve([
+          {
+            transactionHash: realTxHash,
+            // Only the event selector in topics — txHash is non-indexed, in data instead
+            topics: ['0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e'],
+            data: safeTxHash + '0000000000000000000000000000000000000000000000000000000000000000',
+          },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const promise = resilientConfirm(walletConfirm, safeTxHash, mockConfig, 1, {
+      contractAddress,
+      sender,
+    });
+
+    await vi.advanceTimersByTimeAsync(15100);
+    const result = await promise;
+
+    expect(result).toEqual({ type: ProviderType.Viem, receipt: onChainReceipt });
+  });
+
+  test('wallet confirm wins when it resolves before event polling fires', async () => {
+    const walletReceipt = {
+      type: 'ethersV5',
+      receipt: { transactionHash: '0xhash', status: 'success' },
+    };
+    const walletConfirm = vi.fn().mockResolvedValue(walletReceipt);
+    mockGetLogs.mockResolvedValue([]);
+
+    const promise = resilientConfirm(walletConfirm, '0xhash', mockConfig, 1, {
+      contractAddress: '0xContract',
+      sender: '0xSender1234567890abcdef1234567890abcdef1234',
+    });
+
+    // Wallet resolves immediately before the 15s event poll initial delay fires
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe(walletReceipt);
+    // getLogs should not have been called since event polling hasn't started
+    expect(mockGetLogs).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/chains/rpcUtils.ts
+++ b/src/features/chains/rpcUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { ChainMetadata, ProviderType, ViemProvider } from '@hyperlane-xyz/sdk';
-import { getPublicClient } from '@wagmi/core';
+import { getAccount, getPublicClient, switchChain } from '@wagmi/core';
 import { BigNumber } from 'ethers';
 import { type Chain, createPublicClient, custom } from 'viem';
 import { type Config as WagmiConfig } from 'wagmi';
@@ -150,4 +150,51 @@ export async function preEstimateGasForEvmTxs(
       logger.warn('Gas pre-estimation failed, wallet will estimate during signing', e);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// WalletConnect chain-switch resilience
+// ---------------------------------------------------------------------------
+
+const CHAIN_SWITCH_POLL_MS = 500;
+const CHAIN_SWITCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Poll wagmi's getAccount until the active chain matches `chainId`.
+ *
+ * WalletConnect with MetaMask mobile can take several seconds after switchChain
+ * resolves before the wagmi store reflects the new chain. Polling here avoids
+ * the hard-coded 2 s sleep in @hyperlane-xyz/widgets which is often too short.
+ */
+export async function waitForChainSwitch(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  timeoutMs = CHAIN_SWITCH_TIMEOUT_MS,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (getAccount(wagmiConfig).chainId === chainId) return;
+    await new Promise<void>((r) => setTimeout(r, CHAIN_SWITCH_POLL_MS));
+  }
+  throw new Error(
+    `ChainMismatchError: wallet did not switch to chain ${chainId} within ${timeoutMs / 1000}s`,
+  );
+}
+
+/**
+ * Switch the wallet to `chainId` (if not already there) and wait for wagmi to
+ * reflect the change before returning. Safe to call before every EVM transaction.
+ */
+export async function ensureWalletOnChain(
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+): Promise<void> {
+  if (getAccount(wagmiConfig).chainId === chainId) return;
+  try {
+    await switchChain(wagmiConfig, { chainId });
+  } catch {
+    // Ignore — wallet may reject if already on the right chain or user cancels.
+    // waitForChainSwitch below will throw with a clear message if it still fails.
+  }
+  await waitForChainSwitch(wagmiConfig, chainId);
 }

--- a/src/features/chains/safeWalletUtils.ts
+++ b/src/features/chains/safeWalletUtils.ts
@@ -1,0 +1,279 @@
+/**
+ * Safe (Gnosis) wallet transaction confirmation utilities.
+ *
+ * Problem: Safe wallets return a `safeTxHash` from `sendTransaction` that does
+ * not exist on-chain. Calling `waitForTransactionReceipt` on a safeTxHash hangs
+ * indefinitely because the hash never appears in a block.
+ *
+ * Solution: race the wallet's confirm() callback against event-based log polling.
+ * Two polling strategies cover all known Safe configurations:
+ *   1. Target-contract events where the sender appears as an indexed topic
+ *      (ERC20 Approval / Transfer: owner/from = Safe address).
+ *   2. Safe-contract ExecutionSuccess events keyed on the safeTxHash itself
+ *      (catches transferRemote and other calls where the target contract does
+ *      not index the sender).
+ */
+
+import { ProviderType, TypedTransactionReceipt } from '@hyperlane-xyz/sdk';
+import { getPublicClient } from '@wagmi/core';
+import { type Config as WagmiConfig } from 'wagmi';
+import { logger } from '../../utils/logger';
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const EVENT_POLL_INITIAL_DELAY_MS = 15_000; // wait before first event poll
+const MAX_POLL_DURATION_MS = 60 * 60 * 1_000; // 1 hour
+const MAX_FIBONACCI_DELAY_MS = 30_000; // cap individual interval at 30s
+const TX_REVERTED_ERROR = 'Transaction reverted on-chain';
+
+// ---------------------------------------------------------------------------
+// Fibonacci delay generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Fibonacci delay generator for polling intervals (in milliseconds).
+ * Yields: 1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000, 30000, 30000, …
+ */
+export function* fibonacciDelays(maxDelayMs = MAX_FIBONACCI_DELAY_MS): Generator<number> {
+  let a = 1_000;
+  let b = 1_000;
+  while (true) {
+    yield Math.min(a, maxDelayMs);
+    [a, b] = [b, a + b];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Sleep that rejects on abort signal. */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('Sleep cancelled'));
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Poll the blockchain for events that confirm a Safe wallet transaction.
+ *
+ * Two strategies run in each polling cycle:
+ *
+ * 1. Target-contract strategy: watch `contractAddress` for any event where the
+ *    sender appears as an indexed topic. Covers ERC20 Approval/Transfer where
+ *    `owner`/`from` = Safe address.
+ *
+ * 2. Safe-contract strategy: watch the sender address itself for any event
+ *    where the wallet-returned hash appears as a topic. Safe emits
+ *    `ExecutionSuccess(bytes32 indexed txHash, uint256 payment)` when any tx
+ *    executes, with `txHash` = the safeTxHash we received from `sendTransaction`.
+ *    This catches transactions (like transferRemote) whose target contract does
+ *    not index the sender in any event.
+ *
+ * Completely chain-agnostic — no Safe infrastructure URLs needed.
+ */
+async function pollForContractEvent(
+  contractAddress: string,
+  sender: string,
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  signal: AbortSignal,
+): Promise<TypedTransactionReceipt> {
+  const publicClient = getPublicClient(wagmiConfig, { chainId });
+  if (!publicClient) throw new Error('No public client available for event polling');
+
+  const startTime = Date.now();
+
+  // Capture block number BEFORE sleeping — the Safe tx may be mined during
+  // the delay, and we'd miss it if we snapshot the block after sleeping.
+  // Subtract a small buffer to cover any latency between sendTransaction
+  // returning and this function starting.
+  const currentBlock = await publicClient.getBlockNumber();
+  const startBlock = currentBlock > 10n ? currentBlock - 10n : 0n;
+
+  // Wait before first poll — give wallet confirm a chance first
+  await abortableSleep(EVENT_POLL_INITIAL_DELAY_MS, signal);
+
+  const delays = fibonacciDelays();
+  const paddedSender = ('0x' + sender.slice(2).toLowerCase().padStart(64, '0')) as `0x${string}`;
+  const normalizedTxHash = txHash.toLowerCase();
+
+  while (!signal.aborted) {
+    if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
+      throw new Error('Event polling timed out');
+    }
+
+    try {
+      // Strategy 1: target contract — find events where sender is a topic
+      // (covers ERC20 Approval/Transfer where owner/from = Safe address)
+      const [contractLogs, senderLogs] = await Promise.all([
+        publicClient.getLogs({
+          address: contractAddress as `0x${string}`,
+          fromBlock: startBlock,
+          toBlock: 'latest',
+        }),
+        // Strategy 2: Safe contract — find ExecutionSuccess(safeTxHash, ...)
+        // where our wallet-returned hash appears as a topic
+        publicClient.getLogs({
+          address: sender as `0x${string}`,
+          fromBlock: startBlock,
+          toBlock: 'latest',
+        }),
+      ]);
+
+      const matchingLog =
+        contractLogs.find((log) =>
+          log.topics.some((topic) => topic?.toLowerCase() === paddedSender),
+        ) ??
+        senderLogs.find(
+          (log) =>
+            // Newer Safe versions: txHash is indexed → appears in topics
+            log.topics.some((topic) => topic?.toLowerCase() === normalizedTxHash) ||
+            // Older Safe versions: txHash is non-indexed → first 32 bytes of data
+            // ExecutionSuccess(bytes32 txHash, uint256 payment) ABI encoding
+            (log.data?.length >= 66 && log.data.slice(0, 66).toLowerCase() === normalizedTxHash),
+        );
+
+      if (matchingLog) {
+        const receipt = await publicClient.getTransactionReceipt({
+          hash: matchingLog.transactionHash,
+        });
+
+        if (receipt.status === 'reverted') {
+          throw new Error(TX_REVERTED_ERROR);
+        }
+
+        logger.debug('Event polling confirmed tx:', matchingLog.transactionHash);
+        return { type: ProviderType.Viem, receipt } as TypedTransactionReceipt;
+      }
+    } catch (error: any) {
+      if (error?.message === TX_REVERTED_ERROR) throw error;
+      // RPC hiccup — retry
+    }
+
+    const delay = delays.next().value!;
+    await abortableSleep(delay, signal);
+  }
+
+  throw new Error('Event polling cancelled');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ResilientConfirmOptions {
+  /** Contract address being called (enables event-based fallback for Safe wallets) */
+  contractAddress?: string;
+  /** Sender address (Safe address — used with contractAddress for event filtering) */
+  sender?: string;
+}
+
+/**
+ * Await wallet confirm() with revert detection, falling back to contract event
+ * polling for Safe (Gnosis) wallets.
+ *
+ * confirm() in @hyperlane-xyz/widgets calls wagmi's waitForTransactionReceipt
+ * via the public client (raceTransport) — not through the WalletConnect relay.
+ * For regular wallets this resolves normally; for Safe wallets it hangs because
+ * the hash returned by sendTransaction is a safeTxHash that doesn't exist on-chain.
+ *
+ * When contractAddress and sender are provided (Safe path), a second leg watches
+ * contract logs for the actual on-chain tx. Whichever leg resolves first wins.
+ *
+ * Semantics:
+ * - Any leg fulfills → resolve immediately, abort the other.
+ * - Either leg returns a reverted receipt → reject immediately.
+ * - A leg fails non-definitively → keep the other alive.
+ * - Both legs fail → surface the wallet error.
+ */
+export async function resilientConfirm(
+  walletConfirm: () => Promise<TypedTransactionReceipt>,
+  txHash: string,
+  wagmiConfig: WagmiConfig,
+  chainId: number,
+  options?: ResilientConfirmOptions,
+): Promise<TypedTransactionReceipt> {
+  // Non-Safe path: confirm() already polls via raceTransport, just await + revert check.
+  if (!options?.contractAddress || !options?.sender) {
+    const receipt = await walletConfirm();
+    if ((receipt as any)?.receipt?.status === 'reverted') {
+      throw new Error(TX_REVERTED_ERROR);
+    }
+    return receipt;
+  }
+
+  // Safe path: race wallet confirm against event-based polling.
+  const controller = new AbortController();
+  const cleanup = () => controller.abort();
+
+  let failedCount = 0;
+  let walletError: Error | undefined;
+
+  let signalAllFailed!: () => void;
+  const allFailedBarrier = new Promise<void>((r) => {
+    signalAllFailed = r;
+  });
+
+  const onLegFail = (err: Error, isWallet: boolean) => {
+    if (isWallet) walletError = err;
+    failedCount++;
+    if (failedCount >= 2) signalAllFailed();
+  };
+
+  // Wallet leg: check revert on success; swallow non-revert errors to keep event leg alive
+  const walletLeg = walletConfirm()
+    .then((receipt) => {
+      if ((receipt as any)?.receipt?.status === 'reverted') {
+        throw new Error(TX_REVERTED_ERROR);
+      }
+      return receipt;
+    })
+    .catch((err) => {
+      if (err?.message === TX_REVERTED_ERROR) throw err;
+      onLegFail(err, true);
+      return new Promise<TypedTransactionReceipt>(() => {}); // hang until event leg settles
+    });
+
+  // Event leg: watches contract logs for Safe/non-standard wallets
+  const eventLeg = pollForContractEvent(
+    options.contractAddress,
+    options.sender,
+    txHash,
+    wagmiConfig,
+    chainId,
+    controller.signal,
+  ).catch((err) => {
+    if (err?.message === TX_REVERTED_ERROR) throw err;
+    onLegFail(err, false);
+    return new Promise<TypedTransactionReceipt>(() => {});
+  });
+
+  // All-failed leg: rejects with wallet error when both legs have failed
+  const allFailedLeg = allFailedBarrier.then((): never => {
+    throw walletError ?? new Error('All confirmation methods failed');
+  });
+
+  eventLeg.catch(() => {});
+  allFailedLeg.catch(() => {});
+
+  try {
+    const result = await Promise.race([walletLeg, eventLeg, allFailedLeg]);
+    cleanup();
+    return result;
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+}

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -148,6 +148,16 @@ vi.mock('../../chains/utils', () => ({
   getChainDisplayName: getChainDisplayNameMock,
 }));
 
+vi.mock('../../chains/rpcUtils', () => ({
+  ensureWalletOnChain: vi.fn(() => Promise.resolve()),
+  preEstimateGasForEvmTxs: vi.fn(),
+}));
+
+vi.mock('../../chains/safeWalletUtils', () => ({
+  // Pass through to wallet confirm — resilientConfirm is tested in safeWalletUtils.test.ts
+  resilientConfirm: vi.fn((walletConfirm: () => Promise<any>) => walletConfirm()),
+}));
+
 vi.mock('../../tokens/hooks', () => ({
   useWarpCore: () => warpCoreMock,
   getTokenByIndex: getTokenByIndexMock,

--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -13,6 +13,8 @@ const {
   tryGetMsgIdMock,
   sendTransactionMock,
   sendMultiTransactionMock,
+  mockEnsureWalletOnChain,
+  mockPreEstimateGasForEvmTxs,
   populateApproveTxMock,
   isApproveRequiredAdapterMock,
   EvmTokenAdapterMock,
@@ -35,6 +37,8 @@ const {
   const tryGetMsgIdMock = vi.fn(() => 'msg-1');
   const sendTransactionMock = vi.fn();
   const sendMultiTransactionMock = vi.fn();
+  const mockEnsureWalletOnChain = vi.fn(() => Promise.resolve());
+  const mockPreEstimateGasForEvmTxs = vi.fn(() => Promise.resolve());
   const populateApproveTxMock = vi.fn(() => Promise.resolve({ to: 'router' }));
   const isApproveRequiredAdapterMock = vi.fn(() => Promise.resolve(true));
   const EvmTokenAdapterMock = vi.fn(() => ({
@@ -57,6 +61,7 @@ const {
     tryGetExplorerAddressUrl: vi.fn(),
     tryGetExplorerTxUrl: vi.fn(),
     getProviderNetwork: vi.fn(),
+    getChainMetadata: vi.fn(() => ({ chainId: 11155111 })), // Sepolia
   } as any;
 
   const warpCoreMock = {
@@ -72,6 +77,11 @@ const {
       sendTransaction: sendTransactionMock,
       sendMultiTransaction: sendMultiTransactionMock,
     },
+    // 'ethereum' matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+    ethereum: {
+      sendTransaction: sendTransactionMock,
+      sendMultiTransaction: sendMultiTransactionMock,
+    },
   } as any;
 
   const accountsResponse = {
@@ -79,7 +89,10 @@ const {
   } as any;
 
   const activeChainsResponse = {
-    chains: { evm: { chainName: 'ethereum' } },
+    chains: {
+      evm: { chainName: 'ethereum' },
+      ethereum: { chainName: 'sepolia' }, // used when originToken.protocol === 'ethereum'
+    },
   } as any;
 
   const config = {
@@ -99,6 +112,8 @@ const {
     tryGetMsgIdMock,
     sendTransactionMock,
     sendMultiTransactionMock,
+    mockEnsureWalletOnChain,
+    mockPreEstimateGasForEvmTxs,
     populateApproveTxMock,
     isApproveRequiredAdapterMock,
     EvmTokenAdapterMock,
@@ -183,6 +198,11 @@ vi.mock('wagmi', () => ({
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: () => undefined,
+}));
+
+vi.mock('../../chains/rpcUtils', () => ({
+  ensureWalletOnChain: (...args: any[]) => mockEnsureWalletOnChain(...args),
+  preEstimateGasForEvmTxs: (...args: any[]) => mockPreEstimateGasForEvmTxs(...args),
 }));
 
 describe('useTokenTransfer', () => {
@@ -671,6 +691,104 @@ describe('useTokenTransfer', () => {
         0,
         TransferStatus.ConfirmedTransfer,
         expect.objectContaining({ originTxHash: '0xtransfer' }),
+      );
+    });
+  });
+
+  describe('EVM chain-switch guard (ensureWalletOnChain)', () => {
+    // Use protocol:'ethereum' to exercise the ProtocolType.Ethereum branch,
+    // which is the branch that calls ensureWalletOnChain.
+    const evmToken = {
+      protocol: 'ethereum', // matches ProtocolType.Ethereum from @hyperlane-xyz/utils
+      symbol: 'TEST',
+      decimals: 18,
+      chainName: 'sepolia',
+      addressOrDenom: '0xtoken',
+      collateralAddressOrDenom: '0xcollateral',
+      isNft: () => false,
+      amount: vi.fn(() => ({ amount: 'raw-amount' })),
+      getConnectionForChain: vi.fn(() => ({
+        token: { addressOrDenom: '0xdest-token', protocol: 'ethereum', decimals: 18, scale: 18 },
+      })),
+    } as any;
+
+    const evmValues = {
+      origin: 'sepolia',
+      destination: 'dest-chain',
+      tokenIndex: 0,
+      amount: '1.0',
+      recipient: '0xrecipient',
+    } as any;
+
+    beforeEach(() => {
+      config.enablePruvOriginFeeUSDC = false; // skip pruv logic for these tests
+      getTokenByIndexMock.mockReturnValue(evmToken);
+      warpCoreMock.getTransferRemoteTxs.mockResolvedValue([
+        {
+          category: warpTxCategories.Transfer,
+          type: 'ethereum',
+          transaction: { to: '0xrouter' },
+        },
+      ]);
+      mockEnsureWalletOnChain.mockResolvedValue(undefined);
+      mockPreEstimateGasForEvmTxs.mockResolvedValue(undefined);
+    });
+
+    it('calls ensureWalletOnChain with wagmiConfig and the origin chainId before sending', async () => {
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      // wagmiConfig is {} (from useConfig mock), chainId is 11155111 (Sepolia from getChainMetadata mock)
+      expect(mockEnsureWalletOnChain).toHaveBeenCalledWith({}, 11155111);
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(
+        0,
+        TransferStatus.ConfirmedTransfer,
+        expect.objectContaining({ originTxHash: '0xtx' }),
+      );
+    });
+
+    it('surfaces ChainMismatchError from ensureWalletOnChain as a chain mismatch toast', async () => {
+      mockEnsureWalletOnChain.mockRejectedValue(
+        new Error('ChainMismatchError: wallet did not switch'),
+      );
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(updateTransferStatusMock).toHaveBeenCalledWith(0, TransferStatus.Failed);
+      expect(toastErrorMock).toHaveBeenCalledWith('Wallet must be connected to origin chain', {
+        autoClose: 8000,
+        ariaLabel: 'Transfer Failed',
+        theme: 'colored',
+      });
+      // sendTransaction should never be reached
+      expect(sendTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('calls preEstimateGasForEvmTxs after ensureWalletOnChain succeeds', async () => {
+      const confirm = vi.fn().mockResolvedValue({ type: 'ethers', receipt: { hash: '0xtx' } });
+      sendTransactionMock.mockResolvedValue({ hash: '0xtx', confirm });
+
+      const { result } = renderHook(() => useTokenTransfer());
+
+      await act(async () => {
+        await result.current.triggerTransactions(evmValues);
+      });
+
+      expect(mockPreEstimateGasForEvmTxs).toHaveBeenCalledWith(
+        {}, // wagmiConfig
+        11155111, // chainId
+        '0xsender',
+        expect.any(Array),
       );
     });
   });

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -20,6 +20,7 @@ import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { ensureWalletOnChain, preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { resilientConfirm } from '../chains/safeWalletUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -250,15 +251,10 @@ async function executeTransfer({
       }
     }
 
-    // Pre-estimate gas via the CORS-resilient public client so wagmi doesn't
-    // attempt estimation through the WalletConnect connector's rpcMap.
-    if (originProtocol === ProtocolType.Ethereum) {
-      const chainId = multiProvider.getChainMetadata(origin).chainId as number;
-      // Ensure the wallet is on the origin chain before submitting. WalletConnect
-      // with MetaMask mobile can take >2 s to propagate a chain switch back to
-      // wagmi's store, so we poll until the change is confirmed (up to 30 s).
+    const isEvm = originProtocol === ProtocolType.Ethereum;
+    const chainId = isEvm ? (multiProvider.getChainMetadata(origin).chainId as number) : 0;
+    if (isEvm) {
       await ensureWalletOnChain(wagmiConfig, chainId);
-      await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, txs as any);
     }
 
     const hashes: string[] = [];
@@ -286,6 +282,15 @@ async function executeTransfer({
       hashes.push(hash);
     } else {
       for (const tx of txs) {
+        // Estimate gas right before sending each tx via the CORS-resilient
+        // public client so wagmi doesn't fall back to the WalletConnect
+        // connector's rpcMap (which may be CORS-blocked). Doing this per-tx
+        // (rather than upfront for all txs) ensures that when we reach
+        // transferRemote, any prior approvals are already confirmed on-chain
+        // and the simulation succeeds with the correct allowance state.
+        if (isEvm) {
+          await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, [tx as any]);
+        }
         updateTransferStatus(
           transferIndex,
           (transferStatus = txCategoryToStatuses[tx.category][0]),
@@ -300,12 +305,27 @@ async function executeTransfer({
           transferIndex,
           (transferStatus = txCategoryToStatuses[tx.category][1]),
         );
-        txReceipt = await confirm();
+        // Race wallet confirmation against direct RPC polling for EVM chains.
+        // WalletConnect behaviour varies across wallets — some fail to resolve
+        // the confirm callback even after the tx lands on-chain.
+        // Also pass contract address + sender for event-based fallback which
+        // handles Safe (Gnosis) wallets that return a safeTxHash instead of
+        // an on-chain txHash.
+        txReceipt = isEvm
+          ? await resilientConfirm(confirm, hash, wagmiConfig, chainId, {
+              contractAddress: (tx.transaction as Record<string, any>).to,
+              sender,
+            })
+          : await confirm();
+        // Extract the real on-chain txHash from the receipt. This may differ
+        // from `hash` when a Safe wallet returns a safeTxHash instead of the
+        // actual on-chain hash (detected via event-based polling).
+        const confirmedHash = (txReceipt?.receipt as Record<string, any>)?.transactionHash ?? hash;
         const description = toTitleCase(tx.category);
-        logger.debug(`${description} transaction confirmed, hash:`, hash);
-        toastTxSuccess(`${description} transaction sent!`, hash, origin);
+        logger.debug(`${description} transaction confirmed, hash:`, confirmedHash);
+        toastTxSuccess(`${description} transaction sent!`, confirmedHash, origin);
 
-        hashes.push(hash);
+        hashes.push(confirmedHash);
       }
     }
 

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
-import { preEstimateGasForEvmTxs } from '../chains/rpcUtils';
+import { ensureWalletOnChain, preEstimateGasForEvmTxs } from '../chains/rpcUtils';
 import { getChainDisplayName } from '../chains/utils';
 import { AppState, useStore } from '../store';
 import { getTokenByIndex, useWarpCore } from '../tokens/hooks';
@@ -254,6 +254,10 @@ async function executeTransfer({
     // attempt estimation through the WalletConnect connector's rpcMap.
     if (originProtocol === ProtocolType.Ethereum) {
       const chainId = multiProvider.getChainMetadata(origin).chainId as number;
+      // Ensure the wallet is on the origin chain before submitting. WalletConnect
+      // with MetaMask mobile can take >2 s to propagate a chain switch back to
+      // wagmi's store, so we poll until the change is confirmed (up to 30 s).
+      await ensureWalletOnChain(wagmiConfig, chainId);
       await preEstimateGasForEvmTxs(wagmiConfig, chainId, sender, txs as any);
     }
 


### PR DESCRIPTION
Cherry-pick of #157 onto `main`. Depends on #166 (branched from it).

## Summary

- Safe (Gnosis) wallets return a `safeTxHash` instead of an on-chain `txHash` from `sendTransaction`, causing the wallet confirm callback to hang indefinitely since the hash never exists on-chain
- Added `resilientConfirm` that races the wallet's confirm callback against event-based log polling, using two strategies per cycle:
  1. **Target-contract strategy**: watch the called contract for events where the Safe address is an indexed topic (covers ERC20 Approval/Transfer)
  2. **Safe-contract strategy**: watch the Safe contract itself for `ExecutionSuccess` events matching the `safeTxHash` — handles both Safe versions:
     - Newer Safe (e.g. Pruv): `ExecutionSuccess(bytes32 indexed txHash, ...)` — hash in topics
     - Older Safe (e.g. Kairos): `ExecutionSuccess(bytes32 txHash, ...)` — hash non-indexed, matched via first 32 bytes of `data`
- For non-Safe wallets, `resilientConfirm` simply awaits `confirm()` with an explicit revert check
- Completely chain-agnostic: works on any EVM chain with any Safe deployment without needing Safe infrastructure URLs
- Moved gas estimation inside the per-tx loop so that `transferRemote` estimation runs after prior approvals are already confirmed on-chain
- Extracts the real on-chain `txHash` from the receipt for explorer links (may differ from the `safeTxHash` returned by `sendTransaction`)

## Changes

- `src/features/chains/safeWalletUtils.ts` (new) — `resilientConfirm` with revert detection, `pollForContractEvent` with dual-strategy event polling and Fibonacci backoff
- `src/features/transfer/useTokenTransfer.ts` — per-tx gas estimation inside the loop; passes contract address + sender to `resilientConfirm`; extracts real on-chain txHash from receipt
- `src/features/chains/__tests__/safeWalletUtils.test.ts` (new) — 11 tests covering fibonacci delays, non-Safe revert detection, event-based polling scenarios
- `src/features/transfer/__tests__/useTokenTransfer.test.ts` — updated mock to import `resilientConfirm` from `safeWalletUtils`

## Test plan

- [ ] Tested with real Safe wallet on MetaMask mobile via WalletConnect
- [ ] Transfer works end-to-end without hanging on confirmation
- [ ] Explorer link shows the correct on-chain txHash