### PR TITLE
Fix pre-commit typecheck failures

### DIFF
--- a/src/features/transfer/__tests__/useTokenTransfer.test.ts
+++ b/src/features/transfer/__tests__/useTokenTransfer.test.ts
@@ -149,8 +149,8 @@ vi.mock('../../chains/utils', () => ({
 }));
 
 vi.mock('../../chains/rpcUtils', () => ({
-  ensureWalletOnChain: vi.fn(() => Promise.resolve()),
-  preEstimateGasForEvmTxs: vi.fn(),
+  ensureWalletOnChain: mockEnsureWalletOnChain,
+  preEstimateGasForEvmTxs: mockPreEstimateGasForEvmTxs,
 }));
 
 vi.mock('../../chains/safeWalletUtils', () => ({
@@ -208,11 +208,6 @@ vi.mock('wagmi', () => ({
 
 vi.mock('@wagmi/core', () => ({
   getPublicClient: () => undefined,
-}));
-
-vi.mock('../../chains/rpcUtils', () => ({
-  ensureWalletOnChain: (...args: any[]) => mockEnsureWalletOnChain(...args),
-  preEstimateGasForEvmTxs: (...args: any[]) => mockPreEstimateGasForEvmTxs(...args),
 }));
 
 describe('useTokenTransfer', () => {

--- a/src/features/wallet/context/CosmosWalletContext.tsx
+++ b/src/features/wallet/context/CosmosWalletContext.tsx
@@ -8,7 +8,7 @@ import { cosmoshub } from '@hyperlane-xyz/registry';
 import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { getCosmosKitChainConfigs } from '@hyperlane-xyz/widgets';
 import '@interchain-ui/react/styles';
-import { PropsWithChildren, useMemo } from 'react';
+import { ComponentProps, PropsWithChildren, useMemo } from 'react';
 import { APP_DESCRIPTION, APP_NAME, APP_URL } from '../../../consts/app';
 import { config } from '../../../consts/config';
 import { useMultiProvider } from '../../chains/hooks';
@@ -27,12 +27,28 @@ export function CosmosWalletContext({ children }: PropsWithChildren<unknown>) {
     return getCosmosKitChainConfigs(multiProvider);
   }, [chainMetadata]);
   const leapWithoutSnap = leapWallets.filter((wallet) => !wallet.walletName.includes('snap'));
+  const chainProviderChains = chains as ComponentProps<typeof ChainProvider>['chains'];
+  const signerOptions = {
+    signingCosmwasm: () => {
+      return {
+        // TODO cosmos get gas price from registry or RPC
+        gasPrice: GasPrice.fromString('0.03token'),
+      };
+    },
+    signingStargate: () => {
+      return {
+        // TODO cosmos get gas price from registry or RPC
+        gasPrice: GasPrice.fromString('0.2tia'),
+      };
+    },
+  } as unknown as ComponentProps<typeof ChainProvider>['signerOptions'];
+
   // TODO replace Chakra here with a custom modal for ChainProvider
   // Using Chakra + @cosmos-kit/react instead of @cosmos-kit/react-lite adds about 600Kb to the bundle
   return (
     <ChakraProvider theme={theme}>
       <ChainProvider
-        chains={chains}
+        chains={chainProviderChains}
         assetLists={assets}
         wallets={[...keplrWallets, ...cosmostationWallets, ...leapWithoutSnap]}
         walletConnectOptions={{
@@ -46,20 +62,7 @@ export function CosmosWalletContext({ children }: PropsWithChildren<unknown>) {
             },
           },
         }}
-        signerOptions={{
-          signingCosmwasm: () => {
-            return {
-              // TODO cosmos get gas price from registry or RPC
-              gasPrice: GasPrice.fromString('0.03token'),
-            };
-          },
-          signingStargate: () => {
-            return {
-              // TODO cosmos get gas price from registry or RPC
-              gasPrice: GasPrice.fromString('0.2tia'),
-            };
-          },
-        }}
+        signerOptions={signerOptions}
         modalTheme={{ defaultTheme: 'light' }}
       >
         {children}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "preserveSymlinks": true,
+    "preserveSymlinks": false,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- fix the Husky pre-commit failure on `staging`
- make `pnpm typecheck` pass again so `.husky/pre-commit` can complete
- keep the fix scoped to the TypeScript issues that were blocking commits

## What was causing the pre-commit error
`.husky/pre-commit` runs `pnpm typecheck` before `pnpm lint-staged`, so commits were failing during TypeScript validation rather than in Husky itself.

On `staging`, `pnpm typecheck` was failing for three reasons:
- `tsconfig.json` had `preserveSymlinks: true`, which makes TypeScript follow pnpm symlinked package paths more literally. In this repo that surfaced type errors from dependency internals such as `@safe-global/protocol-kit`, so pre-commit failed before any staged-file checks could run.
- `src/features/transfer/__tests__/useTokenTransfer.test.ts` mocked `../../chains/rpcUtils` twice. The second mock used spread forwarding (`...args`) into `mockEnsureWalletOnChain` / `mockPreEstimateGasForEvmTxs`, which triggers `TS2556` under the current compiler settings.
- `src/features/wallet/context/CosmosWalletContext.tsx` passed `chains` and `signerOptions` directly into `ChainProvider`, which exposed incompatible duplicated types from the Cosmos dependency graph (`@chain-registry/types` and `@cosmjs/math` resolving to different versions). That caused `TS2322` errors during pre-commit typecheck.

## What this PR changes
- set `preserveSymlinks` to `false` in `tsconfig.json`
- remove the duplicate `rpcUtils` mock in `useTokenTransfer.test.ts` and reuse the hoisted typed mocks directly
- normalize `ChainProvider` props in `CosmosWalletContext.tsx` by casting `chains` and `signerOptions` to `ComponentProps<typeof ChainProvider>`-compatible types before passing them through

## Why this fixes it
- disabling `preserveSymlinks` lets TypeScript resolve pnpm dependencies the way the passing branch expects, which prevents dependency-internal errors from breaking `pnpm typecheck`
- reusing the hoisted mocks removes the invalid spread-wrapper mock implementation and clears the `TS2556` failure in the test
- explicitly aligning the `ChainProvider` prop types avoids the duplicated-package type mismatch that was causing the Cosmos wallet context to fail compilation

## Validation
- `pnpm typecheck` passes on this branch
- because Husky pre-commit only runs `pnpm typecheck` and `pnpm lint-staged`, restoring typecheck unblocks commits again