### PR TITLE
Add Solana devnet explorer metadata

### DIFF
--- a/src/consts/chains.yaml
+++ b/src/consts/chains.yaml
@@ -177,6 +177,11 @@ kairos:
     - http: https://public-en-kairos.node.kaia.io
   technicalStack: other
 solanadevnet:
+  blockExplorers:
+    - name: Solana Explorer
+      url: https://explorer.solana.com?cluster=devnet
+      apiUrl: https://explorer.solana.com?cluster=devnet
+      family: other
   chainId: 1399811151
   domainId: 1399811151
   name: solanadevnet


### PR DESCRIPTION
## Summary
- add a block explorer entry for solanadevnet in local chain metadata
- use the Solana Explorer devnet URL format from Hyperlane registry metadata
- enable address and origin transaction explorer links in the transfer details modal for Solana devnet transfers

## Testing
- pnpm vitest run src/features/transfer/__tests__/TransfersDetailsModal.test.tsx